### PR TITLE
feat(tke): support pre-start script for node pools

### DIFF
--- a/docs/resources/tencentcloudenterprise_tke_kubernetes_node_pool.md
+++ b/docs/resources/tencentcloudenterprise_tke_kubernetes_node_pool.md
@@ -52,7 +52,7 @@ resource "tencentcloudenterprise_tke_kubernetes_cluster" "managed_cluster" {
 
 //this is one example of managing node using node pool
 
-resource "tencentcloudenterprise_kubernetes_node_pool" "mynodepool" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "mynodepool" {
   name                     = "mynodepool"
   cluster_id               = tencentcloudenterprise_tke_kubernetes_cluster.managed_cluster.id
   max_size                 = 6
@@ -113,7 +113,7 @@ resource "tencentcloudenterprise_kubernetes_node_pool" "mynodepool" {
 ### Using Spot CVM Instance
 
 ```hcl
-resource "tencentcloudenterprise_kubernetes_node_pool" "mynodepool" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "mynodepool" {
   name                     = "mynodepool"
   cluster_id               = tencentcloudenterprise_tke_kubernetes_cluster.managed_cluster.id
   max_size                 = 6
@@ -241,6 +241,7 @@ The `node_config` object supports the following:
 * `docker_graph_path` - (Optional, String, ForceNew) Docker graph path. Default is `/var/lib/docker`.
 * `extra_args` - (Optional, List, ForceNew) Custom parameter information related to the node. This is a white-list parameter.
 * `mount_target` - (Optional, String, ForceNew) Mount target. Default is not mounting.
+* `pre_start_user_script` - (Optional, String) Base64-encoded user script, executed before initializing the node, currently only effective for adding existing nodes.
 * `user_data` - (Optional, String, ForceNew) Base64-encoded User Data text, the length limit is 16KB.
 
 The `taints` object supports the following:

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
@@ -43,7 +43,7 @@ Provide a resource to create an auto scaling group for kubernetes cluster.
 
 //this is one example of managing node using node pool
 
-	resource "tencentcloudenterprise_kubernetes_node_pool" "mynodepool" {
+	resource "tencentcloudenterprise_tke_kubernetes_node_pool" "mynodepool" {
 	  name = "mynodepool"
 	  cluster_id = tencentcloudenterprise_tke_kubernetes_cluster.managed_cluster.id
 	  max_size = 6
@@ -105,7 +105,7 @@ Provide a resource to create an auto scaling group for kubernetes cluster.
 Using Spot CVM Instance
 ```hcl
 
-	resource "tencentcloudenterprise_kubernetes_node_pool" "mynodepool" {
+	resource "tencentcloudenterprise_tke_kubernetes_node_pool" "mynodepool" {
 	  name = "mynodepool"
 	  cluster_id = tencentcloudenterprise_tke_kubernetes_cluster.managed_cluster.id
 	  max_size = 6
@@ -180,6 +180,7 @@ func init() {
 			"scaling_mode":             "扩缩容模式",
 			"multi_zone_subnet_policy": "多可用区子网策略",
 			"node_config":              "节点配置",
+			"pre_start_user_script":    "Base64 编码的节点初始化前自定义脚本。",
 			"labels":                   "标签",
 			"taints":                   "污点",
 			"delete_keep_instance":     "删除节点池时是否保留节点",
@@ -190,6 +191,24 @@ func init() {
 			"runtime_version":          "容器运行时版本",
 		},
 	})
+}
+
+func tkeNodePoolInstanceAdvancedSetting() map[string]*schema.Schema {
+	nodeConfigSchema := TkeInstanceAdvancedSetting()
+	nodeConfigSchema["pre_start_user_script"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Base64-encoded user script, executed before initializing the node, currently only effective for adding existing nodes.",
+	}
+	return nodeConfigSchema
+}
+
+func tkeGetNodePoolInstanceAdvancedPara(dMap map[string]interface{}, meta interface{}) tke.InstanceAdvancedSettings {
+	setting := tkeGetInstanceAdvancedPara(dMap, meta)
+	if v, ok := dMap["pre_start_user_script"]; ok {
+		setting.PreStartUserScript = helper.String(v.(string))
+	}
+	return setting
 }
 
 // merge `instance_type` to `backup_instance_types` as param `instance_types`
@@ -507,7 +526,7 @@ func resourceTencentCloudKubernetesNodePool() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: TkeInstanceAdvancedSetting(),
+					Schema: tkeNodePoolInstanceAdvancedSetting(),
 				},
 				Description: "Node config.",
 			},
@@ -1102,7 +1121,7 @@ func desiredCapacityOutRange(d *schema.ResourceData) bool {
 }
 
 func resourceKubernetesNodePoolRead(d *schema.ResourceData, meta interface{}) error {
-	defer logElapsed("resource.tencentcloudenterprise_kubernetes_node_pool.read")()
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_node_pool.read")()
 
 	var (
 		logId   = getLogId(contextNil)
@@ -1228,6 +1247,23 @@ func resourceKubernetesNodePoolRead(d *schema.ResourceData, meta interface{}) er
 			annotationsList = append(annotationsList, annotationMap)
 		}
 		_ = d.Set("annotations", annotationsList)
+	}
+
+	if _, configured := d.GetOk("node_config.0.pre_start_user_script"); nodePool.PreStartUserScript != nil || configured {
+		nodeConfig := make(map[string]interface{})
+		if current, ok := helper.InterfacesHeadMap(d, "node_config"); ok {
+			for key, value := range current {
+				nodeConfig[key] = value
+			}
+		}
+		preStartUserScript := ""
+		if nodePool.PreStartUserScript != nil {
+			preStartUserScript = *nodePool.PreStartUserScript
+		}
+		nodeConfig["pre_start_user_script"] = preStartUserScript
+		if err := d.Set("node_config", []interface{}{nodeConfig}); err != nil {
+			return err
+		}
 	}
 
 	//set composed struct
@@ -1389,7 +1425,7 @@ func resourceKubernetesNodePoolRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceKubernetesNodePoolCreate(d *schema.ResourceData, meta interface{}) error {
-	defer logElapsed("resource.tencentcloudenterprise_kubernetes_node_pool.create")()
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_node_pool.create")()
 	var (
 		logId           = getLogId(contextNil)
 		ctx             = context.WithValue(context.TODO(), logIdKey, logId)
@@ -1418,7 +1454,7 @@ func resourceKubernetesNodePoolCreate(d *schema.ResourceData, meta interface{}) 
 
 	//compose InstanceAdvancedSettings
 	if workConfig, ok := helper.InterfacesHeadMap(d, "node_config"); ok {
-		advanced := tkeGetInstanceAdvancedPara(workConfig, meta)
+		advanced := tkeGetNodePoolInstanceAdvancedPara(workConfig, meta)
 		iAdvanced = &advanced
 	}
 
@@ -1519,7 +1555,7 @@ func resourceKubernetesNodePoolCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
-	defer logElapsed("resource.tencentcloudenterprise_kubernetes_node_pool.update")()
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_node_pool.update")()
 
 	var (
 		logId     = getLogId(contextNil)
@@ -1640,6 +1676,21 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
+	if d.HasChange("node_config.0.pre_start_user_script") {
+		userData, _ := d.Get("node_config.0.user_data").(string)
+		preStartUserScript, _ := d.Get("node_config.0.pre_start_user_script").(string)
+		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+			errRet := service.ModifyClusterNodePoolPreStartUserScript(ctx, clusterId, nodePoolId, userData, preStartUserScript)
+			if errRet != nil {
+				return retryError(errRet)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	// ModifyScalingGroup
 	if d.HasChange("scaling_group_name") ||
 		d.HasChange("zones") ||
@@ -1735,7 +1786,7 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceKubernetesNodePoolDelete(d *schema.ResourceData, meta interface{}) error {
-	defer logElapsed("resource.tencentcloudenterprise_kubernetes_node_pool.delete")()
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_node_pool.delete")()
 
 	var (
 		logId              = getLogId(contextNil)

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool_test.go
@@ -16,8 +16,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var testTkeClusterNodePoolName = "tencentcloudenterprise_kubernetes_node_pool"
+var testTkeClusterNodePoolName = "tencentcloudenterprise_tke_kubernetes_node_pool"
 var testTkeClusterNodePoolResourceKey = testTkeClusterNodePoolName + ".np_test"
+
+func TestTkeNodePoolPreStartUserScript(t *testing.T) {
+	nodeConfigSchema := tkeNodePoolInstanceAdvancedSetting()
+	preStartSchema, ok := nodeConfigSchema["pre_start_user_script"]
+	if !ok {
+		t.Fatal("pre_start_user_script is missing from node_config schema")
+	}
+	if !preStartSchema.Optional || preStartSchema.ForceNew {
+		t.Fatal("pre_start_user_script should be optional and updatable")
+	}
+
+	const script = "IyEvYmluL3NoCmVjaG8gaGVsbG8="
+	setting := tkeGetNodePoolInstanceAdvancedPara(map[string]interface{}{
+		"pre_start_user_script": script,
+	}, nil)
+	if setting.PreStartUserScript == nil || *setting.PreStartUserScript != script {
+		t.Fatal("pre_start_user_script was not expanded into InstanceAdvancedSettings")
+	}
+}
 
 func init() {
 	// go test -v ./tencentcloud -sweep=ap-guangzhou -sweep-run=tencentcloudenterprise_node_pool
@@ -279,7 +298,7 @@ data "tencentcloudenterprise_vpc_security_groups" "sg_as" {
 `
 
 const testAccTkeNodePoolCluster string = testAccTkeNodePoolClusterBasic + `
-resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "np_test" {
   name = "mynodepool"
   cluster_id = local.cluster_id
   max_size = 6
@@ -342,7 +361,7 @@ resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
 `
 
 const testAccTkeNodePoolClusterUpdate string = testAccTkeNodePoolClusterBasic + `
-resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "np_test" {
   name = "mynodepoolupdate"
   cluster_id = local.cluster_id
   max_size = 5
@@ -417,7 +436,7 @@ resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
 `
 
 const testAccTkeNodePoolClusterEncrypt = testAccTkeNodePoolClusterBasic + `
-resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "np_test" {
   name = "np_with_disk_encrypt"
   cluster_id = local.cluster_id
   max_size = 3
@@ -457,7 +476,7 @@ resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
 `
 
 const testAccTkeNodePoolClusterGpu string = testAccTkeNodePoolClusterBasic + `
-resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "np_test" {
   name = "gpu_args_node_pool"
   cluster_id = local.cluster_id
   max_size = 1
@@ -575,7 +594,7 @@ func TestAccTencentCloudKubernetesNodePoolResource_NewFields(t *testing.T) {
 }
 
 const testAccTkeNodePoolClusterNewFields = testAccTkeNodePoolClusterBasic + `
-resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "np_test" {
   name = "np_new_fields"
   cluster_id = local.cluster_id
   max_size = 2
@@ -633,7 +652,7 @@ resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
 `
 
 const testAccTkeNodePoolClusterNewFieldsUpdate = testAccTkeNodePoolClusterBasic + `
-resource "tencentcloudenterprise_kubernetes_node_pool" "np_test" {
+resource "tencentcloudenterprise_tke_kubernetes_node_pool" "np_test" {
   name = "np_new_fields_updated"
   cluster_id = local.cluster_id
   max_size = 3

--- a/tencentcloud/service_tencentcloud_tke.go
+++ b/tencentcloud/service_tencentcloud_tke.go
@@ -1549,6 +1549,29 @@ func (me *TkeService) ModifyClusterNodePool(ctx context.Context, clusterId, node
 	return
 }
 
+func (me *TkeService) ModifyClusterNodePoolPreStartUserScript(ctx context.Context, clusterId, nodePoolId, userData, preStartUserScript string) (errRet error) {
+	logId := getLogId(ctx)
+	request := tke.NewModifyClusterNodePoolRequest()
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, reason[%s]\n", logId, request.GetAction(), errRet.Error())
+		}
+	}()
+
+	request.ClusterId = &clusterId
+	request.NodePoolId = &nodePoolId
+	request.UserScript = &userData
+	request.PreStartUserScript = &preStartUserScript
+
+	ratelimit.Check(request.GetAction())
+	_, err := me.client.UseTkeClient().ModifyClusterNodePool(request)
+	if err != nil {
+		errRet = err
+	}
+	return
+}
+
 //func (me *TkeService) ModifyClusterNodePoolDesiredCapacity(ctx context.Context, clusterId, nodePoolId string, desiredCapacity int64) (errRet error) {
 //	logId := getLogId(ctx)
 //	request := tke.NewModifyNodePoolDesiredCapacityAboutAsgRequest()


### PR DESCRIPTION
## Summary

- add optional, updatable `node_config.pre_start_user_script` to `tencentcloudenterprise_tke_kubernetes_node_pool`
- pass the Base64-encoded value during create, restore it during read, and update it through `ModifyClusterNodePool` while preserving `user_data`
- align node-pool examples, resource references, and log keys with the registered `tencentcloudenterprise_tke_kubernetes_node_pool` name
- update the resource documentation and add focused schema/parameter expansion coverage