### PR TITLE
feat(clb): support exclusive instance labels

### DIFF
--- a/docs/resources/tencentcloudenterprise_clb_instance.md
+++ b/docs/resources/tencentcloudenterprise_clb_instance.md
@@ -110,10 +110,12 @@ The following arguments are supported:
 * `project_id` - (Optional, Int, ForceNew) ID of the project within the CLB instance, `0` - Default Project.
 * `security_groups` - (Optional, List: [`String`]) Security groups of the CLB instance. Supports both `OPEN` and `INTERNAL` CLBs.
 * `slave_zone_id` - (Optional, String) Setting slave zone id of cross available zone disaster recovery. this zone will undertake traffic when the master is down.
+* `stgw_set_labels` - (Optional, Set: [`String`], ForceNew) Layer-7 cluster labels used to create an exclusive INTERNAL CLB instance.
 * `subnet_id` - (Optional, String, ForceNew) Subnet ID of the CLB. Effective only for CLB within the VPC.
 * `tags` - (Optional, Map) The available tags within this CLB.
 * `target_region_info_region` - (Optional, String) Region of the target region for cross-region CLB.
 * `target_region_info_vpc_id` - (Optional, String) VPC ID of the target region for cross-region CLB.
+* `tgw_set_labels` - (Optional, Set: [`String`], ForceNew) Layer-4 cluster labels used to create an exclusive INTERNAL CLB instance.
 * `vip` - (Optional, String, ForceNew) Specified VIP for INTERNAL CLB instance. The IP must be available in the selected subnet.
 * `vpc_id` - (Optional, String, ForceNew) VPC ID of the CLB.
 * `zone_id` - (Optional, String) Available zone id, only applicable to open CLB.

--- a/tencentcloud/resource_tc_clb_instance.go
+++ b/tencentcloud/resource_tc_clb_instance.go
@@ -365,6 +365,24 @@ func resourceTencentCloudClbInstance() *schema.Resource {
 				ConflictsWith: []string{"vip"},
 				Description:   "The unique ID of EIP, e.g. `eip-11112222`. Only available for INTERNAL CLB instance to bind EIP.",
 			},
+			"tgw_set_labels": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Layer-4 cluster labels used to create an exclusive INTERNAL CLB instance.",
+			},
+			"stgw_set_labels": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Layer-7 cluster labels used to create an exclusive INTERNAL CLB instance.",
+			},
 		},
 	}
 }
@@ -466,6 +484,20 @@ func resourceTencentCloudClbInstanceCreate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("[CHECK][CLB instance][Create] check: eip_address_id only supports INTERNAL network_type")
 		}
 		request.EipAddressId = helper.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tgw_set_labels"); ok {
+		if networkType != CLB_NETWORK_TYPE_INTERNAL {
+			return fmt.Errorf("[CHECK][CLB instance][Create] check: tgw_set_labels only supports INTERNAL network_type")
+		}
+		request.TgwSetLabels = helper.InterfacesStringsPoint(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("stgw_set_labels"); ok {
+		if networkType != CLB_NETWORK_TYPE_INTERNAL {
+			return fmt.Errorf("[CHECK][CLB instance][Create] check: stgw_set_labels only supports INTERNAL network_type")
+		}
+		request.StgwSetLabels = helper.InterfacesStringsPoint(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("zone_id"); ok {
@@ -652,6 +684,12 @@ func resourceTencentCloudClbInstanceRead(d *schema.ResourceData, meta interface{
 	}
 	if instance.SecureGroups != nil {
 		_ = d.Set("security_groups", helper.StringsInterfaces(instance.SecureGroups))
+	}
+	if instance.TgwSetLabels != nil {
+		_ = d.Set("tgw_set_labels", helper.StringsInterfaces(instance.TgwSetLabels))
+	}
+	if instance.StgwSetLabels != nil {
+		_ = d.Set("stgw_set_labels", helper.StringsInterfaces(instance.StgwSetLabels))
 	}
 	if instance.LoadBalancerId != nil {
 		_ = d.Set("instance_id", instance.LoadBalancerId)

--- a/tencentcloud/resource_tc_clb_instance_test.go
+++ b/tencentcloud/resource_tc_clb_instance_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	clb "terraform-provider-tencentcloudenterprise/sdk/clb/v20180317"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -197,6 +199,69 @@ func TestAccTencentCloudClbInstance_internal(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccTencentCloudClbInstance_exclusiveSpec(t *testing.T) {
+	t.Parallel()
+
+	tgwLabel, stgwLabel := testAccClbExclusiveLabels(t)
+	name := fmt.Sprintf("tf-clb-exclusive-%d", time.Now().Unix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckClbInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccClbInstance_exclusiveSpec, name, tgwLabel, stgwLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClbInstanceExists("tencentcloudenterprise_clb_instance.exclusive"),
+					resource.TestCheckResourceAttr("tencentcloudenterprise_clb_instance.exclusive", "network_type", "INTERNAL"),
+					resource.TestCheckTypeSetElemAttr("tencentcloudenterprise_clb_instance.exclusive", "tgw_set_labels.*", tgwLabel),
+					resource.TestCheckTypeSetElemAttr("tencentcloudenterprise_clb_instance.exclusive", "stgw_set_labels.*", stgwLabel),
+				),
+			},
+			{
+				ResourceName:      "tencentcloudenterprise_clb_instance.exclusive",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccClbExclusiveLabels(t *testing.T) (string, string) {
+	t.Helper()
+	testAccPreCheck(t)
+
+	client, err := sharedClientForRegion(os.Getenv("TENCENTCLOUD_REGION"))
+	if err != nil {
+		t.Fatalf("create CLB acceptance test client: %s", err)
+	}
+	response, err := client.(*TencentCloudClient).apiV3Conn.UseClbClient().DescribeAppIdLabel(clb.NewDescribeAppIdLabelRequest())
+	if err != nil {
+		t.Fatalf("query exclusive CLB labels: %s", err)
+	}
+	if response == nil || response.Response == nil {
+		t.Skip("exclusive CLB label query returned an empty response")
+	}
+
+	var tgwLabel, stgwLabel string
+	for _, item := range response.Response.OwnerLabelSet {
+		if item == nil || item.Label == nil || item.SetType == nil {
+			continue
+		}
+		switch *item.SetType {
+		case "L4_LAN_CLB":
+			tgwLabel = *item.Label
+		case "L7_LAN_CLB":
+			stgwLabel = *item.Label
+		}
+	}
+	if tgwLabel == "" || stgwLabel == "" {
+		t.Skip("the current account has no complete L4/L7 exclusive CLB specification")
+	}
+	return tgwLabel, stgwLabel
 }
 
 func TestAccTencentCloudClbInstance_internalVip(t *testing.T) {
@@ -414,6 +479,25 @@ resource "tencentcloudenterprise_clb_instance" "clb_internal" {
   tags = {
     test = "tf1"
   }
+}
+`
+
+const testAccClbInstance_exclusiveSpec = `
+data "tencentcloudenterprise_vpc_instances" "available" {
+  is_default = true
+}
+
+data "tencentcloudenterprise_vpc_subnets" "available" {
+  vpc_id = data.tencentcloudenterprise_vpc_instances.available.instance_list.0.vpc_id
+}
+
+resource "tencentcloudenterprise_clb_instance" "exclusive" {
+  network_type    = "INTERNAL"
+  clb_name        = "%s"
+  vpc_id          = data.tencentcloudenterprise_vpc_instances.available.instance_list.0.vpc_id
+  subnet_id       = data.tencentcloudenterprise_vpc_subnets.available.instance_list.0.subnet_id
+  tgw_set_labels  = ["%s"]
+  stgw_set_labels = ["%s"]
 }
 `
 


### PR DESCRIPTION
## Summary

- add `tgw_set_labels` and `stgw_set_labels` arguments to the CLB instance resource
- pass the configured labels in the create request and restore returned values to Terraform state
- document the new arguments