### PR TITLE
fix(tke): support automatic formatting for node pool data disks

### DIFF
--- a/docs/resources/tencentcloudenterprise_tke_kubernetes_cluster_attachment.md
+++ b/docs/resources/tencentcloudenterprise_tke_kubernetes_cluster_attachment.md
@@ -116,8 +116,10 @@ The following arguments are supported:
 
 The `data_disk` object supports the following:
 
+* `auto_format_and_mount` - (Optional, Bool, ForceNew) Indicate whether to auto format and mount or not. Default is `false`.
 * `disk_size` - (Optional, Int, ForceNew) Volume of disk in GB. Default is `0`.
 * `disk_type` - (Optional, String, ForceNew) Types of disk, available values: `CLOUD_PREMIUM` and `CLOUD_SSD`.
+* `file_system` - (Optional, String, ForceNew) File system, e.g. `ext3/ext4/xfs`.
 * `mount_target` - (Optional, String, ForceNew) Mount target.
 
 The `worker_config` object supports the following:

--- a/docs/resources/tencentcloudenterprise_tke_kubernetes_node_pool.md
+++ b/docs/resources/tencentcloudenterprise_tke_kubernetes_node_pool.md
@@ -222,18 +222,20 @@ The `auto_scaling_config` object supports the following:
 
 The `data_disk` object supports the following:
 
+* `auto_format_and_mount` - (Optional, Bool, ForceNew) Indicate whether to auto format and mount or not. Default is `false`.
+* `disk_size` - (Optional, Int, ForceNew) Volume of disk in GB. Default is `0`.
+* `disk_type` - (Optional, String, ForceNew) Types of disk, available values: `CLOUD_PREMIUM` and `CLOUD_SSD`.
+* `file_system` - (Optional, String, ForceNew) File system, e.g. `ext3/ext4/xfs`.
+* `mount_target` - (Optional, String, ForceNew) Mount target.
+
+The `data_disk` object supports the following:
+
 * `delete_with_instance` - (Optional, Bool) Indicates whether the disk remove after instance terminated. Default is `false`.
 * `disk_size` - (Optional, Int) Volume of disk in GB. Default is `0`.
 * `disk_type` - (Optional, String) Types of disk. Valid value: `CLOUD_PREMIUM` and `CLOUD_SSD`.
 * `encrypt` - (Optional, Bool) Specify whether to encrypt data disk, default: false. NOTE: Make sure the instance type is offering and the cam role `QcloudKMSAccessForCVMRole` was provided.
 * `snapshot_id` - (Optional, String, ForceNew) Data disk snapshot ID.
 * `throughput_performance` - (Optional, Int) Add extra performance to the data disk. Only works when disk type is `CLOUD_TSSD` or `CLOUD_HSSD` and `data_size` > 460GB.
-
-The `data_disk` object supports the following:
-
-* `disk_size` - (Optional, Int, ForceNew) Volume of disk in GB. Default is `0`.
-* `disk_type` - (Optional, String, ForceNew) Types of disk, available values: `CLOUD_PREMIUM` and `CLOUD_SSD`.
-* `mount_target` - (Optional, String, ForceNew) Mount target.
 
 The `node_config` object supports the following:
 

--- a/tencentcloud/resource_tc_tke_kubernetes_cluster_attachment.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_cluster_attachment.go
@@ -131,8 +131,8 @@ func init() {
 			"data_disk":             "数据盘配置信息。数据盘配置信息。",
 			"disk_type":             "磁盘类型。可用值：`CLOUD_PREMIUM` 和 `CLOUD_SSD`。",
 			"disk_size":             "磁盘容量（单位：GB）。默认为 `0`。",
-			//"file_system":           "文件系统，例如 `ext3/ext4/xfs`。",
-			//"auto_format_and_mount": "是否自动格式化和挂载。默认为 `false`。",
+			"file_system":           "文件系统，例如 `ext3/ext4/xfs`。",
+			"auto_format_and_mount": "是否自动格式化和挂载。默认为 `false`。",
 			"mount_target":          "挂载目标。",
 			//"disk_partition":        "要挂载的设备或分区的名称。注意：此参数不支持在节点池中设置，否则会导致挂载错误。",
 			"extra_args":            "与节点相关的自定义参数信息。这是一个白名单参数。",
@@ -221,20 +221,20 @@ func TkeInstanceAdvancedSetting() map[string]*schema.Schema {
 						Default:     0,
 						Description: "Volume of disk in GB. Default is `0`.",
 					},
-					//"file_system": {
-					//	Type:        schema.TypeString,
-					//	ForceNew:    true,
-					//	Optional:    true,
-					//	Default:     "",
-					//	Description: "File system, e.g. `ext3/ext4/xfs`.",
-					//},
-					//"auto_format_and_mount": {
-					//	Type:        schema.TypeBool,
-					//	Optional:    true,
-					//	ForceNew:    true,
-					//	Default:     false,
-					//	Description: "Indicate whether to auto format and mount or not. Default is `false`.",
-					//},
+					"file_system": {
+						Type:        schema.TypeString,
+						ForceNew:    true,
+						Optional:    true,
+						Default:     "",
+						Description: "File system, e.g. `ext3/ext4/xfs`.",
+					},
+					"auto_format_and_mount": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						ForceNew:    true,
+						Default:     false,
+						Description: "Indicate whether to auto format and mount or not. Default is `false`.",
+					},
 					"mount_target": {
 						Type:        schema.TypeString,
 						Optional:    true,
@@ -401,14 +401,14 @@ func tkeGetInstanceAdvancedPara(dMap map[string]interface{}, meta interface{}) (
 				value              = d.(map[string]interface{})
 				diskType           = value["disk_type"].(string)
 				diskSize           = int64(value["disk_size"].(int))
-				//fileSystem         = value["file_system"].(string)
-				//autoFormatAndMount = value["auto_format_and_mount"].(bool)
+				fileSystem         = value["file_system"].(string)
+				autoFormatAndMount = value["auto_format_and_mount"].(bool)
 				mountTarget        = value["mount_target"].(string)
 				//diskPartition      = value["disk_partition"].(string)
 				dataDisk = tke.DataDisk{
 					DiskType:           &diskType,
-					//FileSystem:         &fileSystem,
-					//AutoFormatAndMount: &autoFormatAndMount,
+					FileSystem:         &fileSystem,
+					AutoFormatAndMount: &autoFormatAndMount,
 					MountTarget:        &mountTarget,
 					//DiskPartition:      &diskPartition,
 				}

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool_test.go
@@ -13,6 +13,7 @@ import (
 	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -35,6 +36,45 @@ func TestTkeNodePoolPreStartUserScript(t *testing.T) {
 	}, nil)
 	if setting.PreStartUserScript == nil || *setting.PreStartUserScript != script {
 		t.Fatal("pre_start_user_script was not expanded into InstanceAdvancedSettings")
+	}
+}
+
+func TestTkeNodePoolDataDiskAutoFormatAndMount(t *testing.T) {
+	nodeConfigSchema := tkeNodePoolInstanceAdvancedSetting()
+	dataDiskResource := nodeConfigSchema["data_disk"].Elem.(*schema.Resource)
+
+	autoFormatSchema, ok := dataDiskResource.Schema["auto_format_and_mount"]
+	if !ok {
+		t.Fatal("node_config.data_disk.auto_format_and_mount is missing from schema")
+	}
+	if autoFormatSchema.Type != schema.TypeBool || !autoFormatSchema.Optional || !autoFormatSchema.ForceNew || autoFormatSchema.Default != false {
+		t.Fatalf("unexpected auto_format_and_mount schema: %#v", autoFormatSchema)
+	}
+
+	setting := tkeGetNodePoolInstanceAdvancedPara(map[string]interface{}{
+		"data_disk": []interface{}{
+			map[string]interface{}{
+				"disk_type":             "CLOUD_SSD",
+				"disk_size":             50,
+				"file_system":           "ext4",
+				"auto_format_and_mount": true,
+				"mount_target":          "/var/lib/containerd",
+			},
+		},
+	}, nil)
+
+	if len(setting.DataDisks) != 1 {
+		t.Fatalf("expected one data disk, got %d", len(setting.DataDisks))
+	}
+	disk := setting.DataDisks[0]
+	if disk.AutoFormatAndMount == nil || !*disk.AutoFormatAndMount {
+		t.Fatalf("expected AutoFormatAndMount=true, got %#v", disk.AutoFormatAndMount)
+	}
+	if disk.FileSystem == nil || *disk.FileSystem != "ext4" {
+		t.Fatalf("expected FileSystem=ext4, got %#v", disk.FileSystem)
+	}
+	if disk.MountTarget == nil || *disk.MountTarget != "/var/lib/containerd" {
+		t.Fatalf("expected MountTarget=/var/lib/containerd, got %#v", disk.MountTarget)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `file_system` and `auto_format_and_mount` support for TKE node data disks
- forward formatting and mount options during node pool creation
- add schema and request-expansion coverage
- update the affected resource documentation