### PR TITLE
fix(tke): prevent repeated apply drift

### DIFF
--- a/tencentcloud/resource_tc_tke_kubernetes_addon_config.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_addon_config.go
@@ -157,7 +157,7 @@ func resourceTencentCloudTkeKubernetesAddonConfigRead(d *schema.ResourceData, me
 	if addon.RawValues != nil {
 		rawValues, err := base64.StdEncoding.DecodeString(*addon.RawValues)
 		if err == nil {
-			_ = d.Set("raw_values", string(rawValues))
+			_ = d.Set("raw_values", addonRawValuesForState(d, string(rawValues)))
 		}
 	}
 	if addon.Phase != nil {
@@ -234,7 +234,9 @@ func resourceTencentCloudTkeKubernetesAddonConfigDelete(d *schema.ResourceData, 
 	return nil
 }
 
-// suppressJSONOrderDiff compares two JSON strings and ignores ordering differences
+// suppressJSONOrderDiff ignores ordering and server-added defaults. Explicitly
+// configured values still produce a diff when the service returns a different
+// value or omits them.
 func suppressJSONOrderDiff(k, old, new string, d *schema.ResourceData) bool {
 	if old == "" && new == "" {
 		return true
@@ -253,5 +255,70 @@ func suppressJSONOrderDiff(k, old, new string, d *schema.ResourceData) bool {
 		return old == new
 	}
 
-	return reflect.DeepEqual(oldJSON, newJSON)
+	return reflect.DeepEqual(oldJSON, newJSON) || jsonValueContains(oldJSON, newJSON)
+}
+
+// addonRawValuesForState keeps the user's configured JSON when TKE only adds
+// server-side defaults. This prevents the expanded response from becoming a
+// new desired configuration while still exposing genuine changes to values
+// explicitly managed by Terraform.
+func addonRawValuesForState(d *schema.ResourceData, remote string) string {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() || !rawConfig.Type().HasAttribute("raw_values") {
+		return remote
+	}
+
+	configuredValue := rawConfig.GetAttr("raw_values")
+	if configuredValue.IsNull() || !configuredValue.IsKnown() {
+		return remote
+	}
+
+	configured := configuredValue.AsString()
+	if jsonContainsConfiguredValues(remote, configured) {
+		return configured
+	}
+
+	return remote
+}
+
+func jsonContainsConfiguredValues(remote, configured string) bool {
+	var remoteJSON, configuredJSON interface{}
+	if err := json.Unmarshal([]byte(remote), &remoteJSON); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(configured), &configuredJSON); err != nil {
+		return false
+	}
+
+	return jsonValueContains(remoteJSON, configuredJSON)
+}
+
+func jsonValueContains(actual, expected interface{}) bool {
+	switch expectedValue := expected.(type) {
+	case map[string]interface{}:
+		actualValue, ok := actual.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		for key, value := range expectedValue {
+			actualItem, exists := actualValue[key]
+			if !exists || !jsonValueContains(actualItem, value) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		actualValue, ok := actual.([]interface{})
+		if !ok || len(actualValue) != len(expectedValue) {
+			return false
+		}
+		for i := range expectedValue {
+			if !jsonValueContains(actualValue[i], expectedValue[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(actual, expected)
+	}
 }

--- a/tencentcloud/resource_tc_tke_kubernetes_addon_config_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_addon_config_test.go
@@ -26,6 +26,9 @@ func TestAccTencentCloudTkeKubernetesAddonConfigResource_basic(t *testing.T) {
 				ResourceName:      "tencentcloudenterprise_tke_kubernetes_addon_config.kubernetes_addon_config",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"raw_values",
+				},
 			},
 		},
 	})

--- a/tencentcloud/resource_tc_tke_kubernetes_cluster_endpoint.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_cluster_endpoint.go
@@ -101,11 +101,13 @@ func resourceTencentCloudTkeClusterEndpoint() *schema.Resource {
 			"cluster_internet_security_group": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Specify security group, NOTE: This argument must not be empty if cluster internet enabled.",
 			},
 			"cluster_internet_domain": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Description: "Domain name for cluster Kube-apiserver internet access. " +
 					" Be careful if you modify value of this parameter, the cluster_external_endpoint value may be changed automatically too.",
 			},
@@ -118,12 +120,14 @@ func resourceTencentCloudTkeClusterEndpoint() *schema.Resource {
 			"cluster_intranet_domain": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Description: "Domain name for cluster Kube-apiserver intranet access." +
 					" Be careful if you modify value of this parameter, the cluster_intranet_endpoint value may be changed automatically too.",
 			},
 			"cluster_intranet_subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Description: "Subnet id who can access this independent cluster, this field must and can only set  when `cluster_intranet` is true." +
 					" `cluster_intranet_subnet_id` can not modify once be set.",
 			},

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
@@ -660,7 +660,6 @@ func resourceTencentCloudKubernetesNodePool() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
-				Computed:    true,
 				Description: "Policy of scaling group termination. Available values: `[\"OLDEST_INSTANCE\"]`, `[\"NEWEST_INSTANCE\"]`.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
## Summary

- retain configured addon values when TKE adds server-side defaults to `raw_values`
- treat endpoint domain, subnet, and security group values as service-computed when omitted
- avoid planning `termination_policies` as unknown when it is omitted from node pool configuration
- update addon import verification for `raw_values`
