### PR TITLE
fix(tke): preserve master config identity across refresh

### DIFF
--- a/tencentcloud/resource_tc_tke_kubernetes_cluster.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_cluster.go
@@ -416,12 +416,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-tencentcloudenterprise/sdk/common/errors"
 	cvm "terraform-provider-tencentcloudenterprise/sdk/cvm/v20170312"
 	tke "terraform-provider-tencentcloudenterprise/sdk/tke/v20180525"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func init() {
@@ -951,6 +951,404 @@ func normalizeMasterConfigBlock(m map[string]interface{}) {
 	}
 }
 
+func bindMasterConfigInstance(existing map[string]interface{}, instance *cvm.Instance) map[string]interface{} {
+	bound := make(map[string]interface{}, len(existing)+1)
+	for key, value := range existing {
+		bound[key] = value
+	}
+	if instance != nil && instance.InstanceId != nil {
+		bound["instance_id"] = helper.PString(instance.InstanceId)
+	}
+	normalizeMasterConfigBlock(bound)
+	return bound
+}
+
+func newMasterConfigFromCvm(instance *cvm.Instance, masterInfo InstanceInfo) map[string]interface{} {
+	mapping := map[string]interface{}{
+		"instance_charge_type_prepaid_period":     1,
+		"instance_charge_type_prepaid_renew_flag": CVM_PREPAID_RENEW_FLAG_NOTIFY_AND_MANUAL_RENEW,
+		"system_disk_pool_group":                  "",
+		"cam_role_name":                           "",
+		"desired_pod_num":                         DefaultDesiredPodNum,
+		"node_role":                               "MASTER_ETCD",
+		"enhanced_security_service":               true,
+		"enhanced_monitor_service":                true,
+		"enhanced_automation_service":             true,
+		"public_ip_assigned":                      false,
+		"internet_charge_type":                    INTERNET_CHARGE_TYPE_TRAFFIC_POSTPAID_BY_HOUR,
+	}
+	if instance == nil {
+		normalizeMasterConfigBlock(mapping)
+		return mapping
+	}
+	if instance.InstanceId != nil {
+		mapping["instance_id"] = helper.PString(instance.InstanceId)
+	}
+	if instance.InstanceName != nil {
+		mapping["instance_name"] = helper.PString(instance.InstanceName)
+	}
+	if instance.InstanceType != nil {
+		mapping["instance_type"] = helper.PString(instance.InstanceType)
+	}
+	if instance.InstanceChargeType != nil {
+		mapping["instance_charge_type"] = helper.PString(instance.InstanceChargeType)
+	}
+	if instance.ImageId != nil {
+		mapping["img_id"] = helper.PString(instance.ImageId)
+	}
+	if instance.VirtualPrivateCloud != nil && instance.VirtualPrivateCloud.SubnetId != nil {
+		mapping["subnet_id"] = helper.PString(instance.VirtualPrivateCloud.SubnetId)
+	}
+	if instance.Placement != nil && instance.Placement.Zone != nil {
+		mapping["availability_zone"] = helper.PString(instance.Placement.Zone)
+	}
+	if instance.SystemDisk != nil {
+		if instance.SystemDisk.DiskType != nil {
+			mapping["system_disk_type"] = helper.PString(instance.SystemDisk.DiskType)
+		}
+		if instance.SystemDisk.DiskSize != nil {
+			mapping["system_disk_size"] = helper.PInt64(instance.SystemDisk.DiskSize)
+		}
+	}
+	if instance.InternetAccessible != nil {
+		if instance.InternetAccessible.InternetChargeType != nil {
+			mapping["internet_charge_type"] = helper.PString(instance.InternetAccessible.InternetChargeType)
+		}
+		if instance.InternetAccessible.InternetMaxBandwidthOut != nil {
+			bandwidth := helper.PInt64(instance.InternetAccessible.InternetMaxBandwidthOut)
+			mapping["internet_max_bandwidth_out"] = bandwidth
+			mapping["public_ip_assigned"] = bandwidth > 0
+		}
+	}
+	if instance.SecurityGroupIds != nil {
+		mapping["security_group_ids"] = helper.StringsInterfaces(instance.SecurityGroupIds)
+	}
+	if instance.RenewFlag != nil && helper.PString(instance.InstanceChargeType) == "PREPAID" {
+		mapping["instance_charge_type_prepaid_renew_flag"] = helper.PString(instance.RenewFlag)
+	}
+	if instance.CamRoleName != nil {
+		mapping["cam_role_name"] = helper.PString(instance.CamRoleName)
+	}
+	if instance.LoginSettings != nil {
+		mapping["key_ids"] = helper.StringsInterfaces(instance.LoginSettings.KeyIds)
+	}
+	if instance.DataDisks != nil {
+		dataDisks := make([]interface{}, 0, len(instance.DataDisks))
+		for _, disk := range instance.DataDisks {
+			if disk == nil {
+				continue
+			}
+			diskConfig := make(map[string]interface{})
+			if disk.DiskType != nil {
+				diskConfig["disk_type"] = helper.PString(disk.DiskType)
+			}
+			if disk.DiskSize != nil {
+				diskConfig["disk_size"] = helper.PInt64(disk.DiskSize)
+			}
+			dataDisks = append(dataDisks, diskConfig)
+		}
+		mapping["data_disk"] = dataDisks
+	}
+	if masterInfo.InstanceRole != "" {
+		mapping["node_role"] = masterInfo.InstanceRole
+	}
+	if masterInfo.InstanceAdvancedSettings != nil {
+		if masterInfo.InstanceAdvancedSettings.DesiredPodNumber != nil {
+			mapping["desired_pod_num"] = helper.PInt64(masterInfo.InstanceAdvancedSettings.DesiredPodNumber)
+		}
+		if masterInfo.InstanceAdvancedSettings.PreStartUserScript != nil {
+			mapping["pre_start_user_script"] = helper.PString(masterInfo.InstanceAdvancedSettings.PreStartUserScript)
+		}
+		if masterInfo.InstanceAdvancedSettings.UserScript != nil {
+			mapping["user_script"] = helper.PString(masterInfo.InstanceAdvancedSettings.UserScript)
+		}
+	}
+	normalizeMasterConfigBlock(mapping)
+	return mapping
+}
+
+func masterConfigMatchesCvmSpec(config map[string]interface{}, instance *cvm.Instance) bool {
+	if instance == nil {
+		return false
+	}
+	matchedField := false
+	if value, _ := config["instance_type"].(string); value != "" {
+		matchedField = true
+		if value != helper.PString(instance.InstanceType) {
+			return false
+		}
+	}
+	if value, _ := config["subnet_id"].(string); value != "" {
+		matchedField = true
+		if instance.VirtualPrivateCloud == nil || value != helper.PString(instance.VirtualPrivateCloud.SubnetId) {
+			return false
+		}
+	}
+	if value, _ := config["availability_zone"].(string); value != "" {
+		matchedField = true
+		if instance.Placement == nil || value != helper.PString(instance.Placement.Zone) {
+			return false
+		}
+	}
+	return matchedField
+}
+
+func matchMasterConfigToCvm(config map[string]interface{}, instances []*cvm.Instance, matched map[string]bool) *cvm.Instance {
+	instanceName, _ := config["instance_name"].(string)
+	var idCandidate *cvm.Instance
+	if instanceId, _ := config["instance_id"].(string); instanceId != "" {
+		for _, instance := range instances {
+			if instance != nil && instance.InstanceId != nil && helper.PString(instance.InstanceId) == instanceId && !matched[instanceId] {
+				// A TypeList plan may carry the computed instance_id from the old
+				// positional element after HCL reorders the blocks. Trust the ID only
+				// when it still agrees with the configured instance_name; otherwise
+				// keep it as a fallback and rebind by name below.
+				if instanceName == "" || helper.PString(instance.InstanceName) == instanceName {
+					return instance
+				}
+				idCandidate = instance
+				break
+			}
+		}
+	}
+
+	var nameCandidate *cvm.Instance
+	for _, instance := range instances {
+		if instance == nil || instance.InstanceId == nil || matched[helper.PString(instance.InstanceId)] {
+			continue
+		}
+		if instanceName != "" && helper.PString(instance.InstanceName) == instanceName {
+			if masterConfigMatchesCvmSpec(config, instance) {
+				return instance
+			}
+			if nameCandidate == nil {
+				nameCandidate = instance
+			}
+		}
+	}
+	if nameCandidate != nil {
+		return nameCandidate
+	}
+	if idCandidate != nil {
+		return idCandidate
+	}
+	if instanceName != "" {
+		return nil
+	}
+
+	for _, instance := range instances {
+		if instance == nil || instance.InstanceId == nil || matched[helper.PString(instance.InstanceId)] {
+			continue
+		}
+		if masterConfigMatchesCvmSpec(config, instance) {
+			return instance
+		}
+	}
+	return nil
+}
+
+func reconcileMasterConfigState(existing []interface{}, instances []*cvm.Instance, masters []InstanceInfo) []interface{} {
+	orderedInstances := make([]*cvm.Instance, 0, len(instances))
+	for _, instance := range instances {
+		if instance != nil && instance.InstanceId != nil {
+			orderedInstances = append(orderedInstances, instance)
+		}
+	}
+	sort.SliceStable(orderedInstances, func(i, j int) bool {
+		leftName := helper.PString(orderedInstances[i].InstanceName)
+		rightName := helper.PString(orderedInstances[j].InstanceName)
+		if leftName == rightName {
+			return helper.PString(orderedInstances[i].InstanceId) < helper.PString(orderedInstances[j].InstanceId)
+		}
+		return leftName < rightName
+	})
+
+	masterById := make(map[string]InstanceInfo, len(masters))
+	for _, master := range masters {
+		masterById[master.InstanceId] = master
+	}
+	matched := make(map[string]bool, len(orderedInstances))
+	reconciled := make([]interface{}, 0, len(orderedInstances))
+
+	// Preserve the configuration order and all create-only fields for masters
+	// that still exist. This is the normal create, scale-out, and scale-in path.
+	for _, raw := range existing {
+		config, ok := raw.(map[string]interface{})
+		if !ok || config == nil {
+			continue
+		}
+		instance := matchMasterConfigToCvm(config, orderedInstances, matched)
+		if instance == nil || instance.InstanceId == nil {
+			continue
+		}
+		instanceId := helper.PString(instance.InstanceId)
+		matched[instanceId] = true
+		reconciled = append(reconciled, bindMasterConfigInstance(config, instance))
+	}
+
+	// Unmatched CVMs are masters created outside the current state (including
+	// import and externally added nodes). Append them in deterministic order.
+	for _, instance := range orderedInstances {
+		if instance == nil || instance.InstanceId == nil {
+			continue
+		}
+		instanceId := helper.PString(instance.InstanceId)
+		if matched[instanceId] {
+			continue
+		}
+		reconciled = append(reconciled, newMasterConfigFromCvm(instance, masterById[instanceId]))
+	}
+	return reconciled
+}
+
+func validateMasterConfigStateSchema(configs []interface{}) error {
+	masterSchema := TkeMasterCvmCreateInfo()
+	for index, raw := range configs {
+		config, ok := raw.(map[string]interface{})
+		if !ok || config == nil {
+			continue
+		}
+		for key := range config {
+			if _, exists := masterSchema[key]; !exists {
+				return fmt.Errorf("master_config.%d contains unsupported state field %q", index, key)
+			}
+		}
+	}
+	return nil
+}
+
+func masterInstancesNotReadyError(masters []InstanceInfo) error {
+	notReady := make([]string, 0)
+	for _, master := range masters {
+		if strings.EqualFold(master.InstanceState, "running") {
+			continue
+		}
+		reason := strings.TrimSpace(master.FailedReason)
+		if reason == "" {
+			reason = "reason not reported by TKE"
+		}
+		notReady = append(notReady, fmt.Sprintf("%s (state: %s, reason: %s)", master.InstanceId, master.InstanceState, reason))
+	}
+	if len(notReady) == 0 {
+		return nil
+	}
+	sort.Strings(notReady)
+	return fmt.Errorf("TKE reported master node(s) that are not ready: %s. Terraform will not submit another master scaling request or automatically delete/recreate control-plane nodes; wait for the TKE operation to finish and all masters to become healthy, then run Terraform again. If the condition persists, investigate the reported TKE reason", strings.Join(notReady, ", "))
+}
+
+type masterInventoryDirection int
+
+const (
+	masterInventoryGrowing   masterInventoryDirection = 1
+	masterInventoryShrinking masterInventoryDirection = -1
+)
+
+func masterConfigInstanceIDs(configs []interface{}) (map[string]bool, error) {
+	ids := make(map[string]bool, len(configs))
+	for _, raw := range configs {
+		config, ok := raw.(map[string]interface{})
+		if !ok || config == nil {
+			return nil, fmt.Errorf("master_config contains an invalid state block")
+		}
+		instanceId, _ := config["instance_id"].(string)
+		if instanceId == "" {
+			name, _ := config["instance_name"].(string)
+			return nil, fmt.Errorf("master_config block %q has no instance_id; refresh state before scaling", name)
+		}
+		if ids[instanceId] {
+			return nil, fmt.Errorf("master_config contains duplicate instance_id %q; refresh and repair state before scaling", instanceId)
+		}
+		ids[instanceId] = true
+	}
+	return ids, nil
+}
+
+func masterInventoryConvergenceError(masters []InstanceInfo, expectedCount int, requiredInstanceIds map[string]bool, direction masterInventoryDirection, operation string) *resource.RetryError {
+	actualCount := len(masters)
+	if actualCount != expectedCount {
+		err := fmt.Errorf("%s is still converging: TKE returned %d master node(s), want %d", operation, actualCount, expectedCount)
+		if (direction == masterInventoryGrowing && actualCount < expectedCount) || (direction == masterInventoryShrinking && actualCount > expectedCount) {
+			return resource.RetryableError(err)
+		}
+		return resource.NonRetryableError(fmt.Errorf("%s; the master inventory moved in an unexpected direction, so Terraform stopped without submitting another scaling request or deleting nodes automatically", err.Error()))
+	}
+
+	liveIds := make(map[string]bool, actualCount)
+	for _, master := range masters {
+		liveIds[master.InstanceId] = true
+	}
+	for instanceId := range requiredInstanceIds {
+		if !liveIds[instanceId] {
+			return resource.NonRetryableError(fmt.Errorf("%s reached the target count, but existing master %s is missing; Terraform stopped without deleting or recreating any master", operation, instanceId))
+		}
+	}
+
+	if err := masterInstancesNotReadyError(masters); err != nil {
+		return resource.RetryableError(fmt.Errorf("%s is still converging: %w", operation, err))
+	}
+	return nil
+}
+
+func validateMasterScalingPreflight(masters []InstanceInfo, sourceCount, targetCount int, requiredInstanceIds map[string]bool, clusterState, operation string) (bool, error) {
+	if !strings.EqualFold(clusterState, "Running") {
+		return false, fmt.Errorf("cluster is currently in %q before %s; Terraform did not submit a new master scaling request. Wait for TKE to finish the existing operation and run Terraform again", clusterState, operation)
+	}
+
+	liveIds := make(map[string]bool, len(masters))
+	for _, master := range masters {
+		liveIds[master.InstanceId] = true
+	}
+	for instanceId := range requiredInstanceIds {
+		if !liveIds[instanceId] {
+			return false, fmt.Errorf("master inventory changed after planning %s: required master %s is missing. Terraform did not submit a scaling request; refresh and review the plan", operation, instanceId)
+		}
+	}
+
+	if len(masters) == targetCount {
+		return true, nil
+	}
+	if len(masters) != sourceCount {
+		return false, fmt.Errorf("master inventory changed after planning %s: TKE now has %d node(s), while the plan was based on %d and targets %d. Terraform did not submit a scaling request; refresh and review the plan", operation, len(masters), sourceCount, targetCount)
+	}
+	if err := masterInstancesNotReadyError(masters); err != nil {
+		return false, fmt.Errorf("cannot start %s while the current master inventory is not healthy: %w", operation, err)
+	}
+	return false, nil
+}
+
+func readMasterScalingPreflight(ctx context.Context, service TkeService, clusterId string, sourceCount, targetCount int, requiredInstanceIds map[string]bool, operation string) (bool, error) {
+	var masters []InstanceInfo
+	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		var inErr error
+		masters, _, inErr = service.DescribeClusterInstances(ctx, clusterId)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	var status *tke.ClusterStatus
+	err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		var inErr error
+		status, inErr = service.DescribeClusterStatus(ctx, clusterId)
+		if inErr != nil {
+			return retryError(inErr)
+		}
+		if status == nil || status.ClusterState == nil {
+			return resource.RetryableError(fmt.Errorf("cluster %s has not reported a state before %s", clusterId, operation))
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return validateMasterScalingPreflight(masters, sourceCount, targetCount, requiredInstanceIds, helper.PString(status.ClusterState), operation)
+}
+
 // expandMasterConfigInstanceAdvancedSettings expands the TKE per-node settings
 // supported by master_config. The returned bool is true only when a non-empty
 // override must be sent to TKE. A zero-value settings object is still useful to
@@ -1022,6 +1420,37 @@ func expandDesiredPodNumberOverride(raw map[string]interface{}) (tke.InstanceAdv
 // but the user's HCL never set the field at all (or vice versa).
 func masterConfigFieldsEquivalent(a, b interface{}) bool {
 	return isMasterConfigZero(a) && isMasterConfigZero(b)
+}
+
+// masterConfigFieldDoesNotRequireMutation reports whether a field difference
+// can be reconciled in state without changing an existing master.
+//
+// hostname is write-only in the current CVM/TKE read APIs. Once another stable
+// identity (instance_name and the old state's instance_id) has matched the
+// block, an omitted hostname means "unknown", not a request to rename the
+// machine. A change between two non-empty hostnames remains unsupported.
+//
+// desired_pod_num uses DefaultDesiredPodNum as "no per-instance override".
+// Older Read implementations persisted TKE's resolved value (for example 128)
+// instead, so a later scale-in could incorrectly see 128 -> 0 as a mutation of
+// every retained master. The default value must inherit the existing remote
+// setting during comparison.
+//
+// user_data is also write-only. Preserve the existing recovery behavior that
+// allows an empty state value to be hydrated from configuration after a remote
+// scale operation completed but Terraform could not persist the planned state.
+func masterConfigFieldDoesNotRequireMutation(field string, oldValue, newValue interface{}) bool {
+	switch field {
+	case "hostname":
+		return isMasterConfigZero(oldValue) || isMasterConfigZero(newValue)
+	case "desired_pod_num":
+		value, ok := newValue.(int)
+		return ok && int64(value) == DefaultDesiredPodNum
+	case "user_data":
+		return isMasterConfigZero(oldValue) && !isMasterConfigZero(newValue)
+	default:
+		return false
+	}
 }
 
 func isMasterConfigZero(v interface{}) bool {
@@ -1100,6 +1529,247 @@ func masterConfigValueEqual(a, b interface{}) bool {
 	default:
 		return reflect.DeepEqual(a, b)
 	}
+}
+
+// masterConfigMutationField returns the first deterministic field that would
+// require mutating an existing master. Computed identity and sensitive values
+// are excluded because scale operations resolve the authoritative instance_id
+// from the old state and never update a retained master's password.
+func masterConfigMutationField(oldConfig, newConfig map[string]interface{}) string {
+	skipFields := map[string]bool{
+		"instance_id": true,
+		"password":    true,
+	}
+	fields := make([]string, 0, len(newConfig))
+	for field := range newConfig {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	for _, field := range fields {
+		if skipFields[field] {
+			continue
+		}
+		newValue := newConfig[field]
+		oldValue := oldConfig[field]
+		if masterConfigFieldDoesNotRequireMutation(field, oldValue, newValue) {
+			continue
+		}
+		if masterConfigFieldsEquivalent(newValue, oldValue) {
+			continue
+		}
+		if !masterConfigValueEqual(newValue, oldValue) {
+			return field
+		}
+	}
+	return ""
+}
+
+// masterConfigRetainedMutation returns an unsupported retained-block change
+// only when the master inventory itself is unchanged. During a pure scale
+// operation, TypeList nested values are positional and cannot be compared
+// safely after blocks have been inserted or removed.
+func masterConfigRetainedMutation(oldMap, newMap map[string]map[string]interface{}, inventoryChanged bool) (string, string) {
+	if inventoryChanged {
+		return "", ""
+	}
+	names := make([]string, 0, len(newMap))
+	for name := range newMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		oldConfig, exists := oldMap[name]
+		if !exists {
+			continue
+		}
+		if field := masterConfigMutationField(oldConfig, newMap[name]); field != "" {
+			return name, field
+		}
+	}
+	return "", ""
+}
+
+// masterConfigStateForInventoryChange keeps authoritative old-state values for
+// retained masters and configuration values for newly added masters. This
+// prevents Terraform's positional TypeList merge from persisting shifted
+// create-only values after a successful scale operation; Read subsequently
+// binds every block to the live CVM instance_id by instance_name.
+func masterConfigStateForInventoryChange(newList []interface{}, oldMap map[string]map[string]interface{}) []interface{} {
+	state := make([]interface{}, 0, len(newList))
+	for _, raw := range newList {
+		config, ok := raw.(map[string]interface{})
+		if !ok || config == nil {
+			continue
+		}
+		name, _ := config["instance_name"].(string)
+		if oldConfig, exists := oldMap[name]; exists {
+			state = append(state, oldConfig)
+			continue
+		}
+		state = append(state, config)
+	}
+	return state
+}
+
+type masterConfigInventoryChange struct {
+	oldMap        map[string]map[string]interface{}
+	newMap        map[string]map[string]interface{}
+	addedBlocks   []map[string]interface{}
+	removedBlocks []map[string]interface{}
+}
+
+// planMasterConfigInventoryChange interprets the complete old/new TypeList
+// values produced by Terraform Core. Identity is based on instance_name;
+// computed or create-only fields are deliberately not used to decide which
+// master is retained or removed.
+func planMasterConfigInventoryChange(oldList, newList []interface{}) (*masterConfigInventoryChange, error) {
+	if len(newList) < 3 || len(newList) > 7 {
+		return nil, fmt.Errorf("TKE independent cluster master_config node count must be between 3 and 7, got %d", len(newList))
+	}
+
+	change := &masterConfigInventoryChange{
+		oldMap: make(map[string]map[string]interface{}, len(oldList)),
+		newMap: make(map[string]map[string]interface{}, len(newList)),
+	}
+	for _, raw := range oldList {
+		config, ok := raw.(map[string]interface{})
+		if !ok || config == nil {
+			return nil, fmt.Errorf("master_config contains an invalid state block")
+		}
+		name, _ := config["instance_name"].(string)
+		if name == "" {
+			return nil, fmt.Errorf("instance_name in master_config must be set and unique")
+		}
+		if _, exists := change.oldMap[name]; exists {
+			return nil, fmt.Errorf("duplicate instance_name %q found in master_config state", name)
+		}
+		change.oldMap[name] = config
+	}
+	for _, raw := range newList {
+		config, ok := raw.(map[string]interface{})
+		if !ok || config == nil {
+			return nil, fmt.Errorf("master_config contains an invalid configuration block")
+		}
+		name, _ := config["instance_name"].(string)
+		if name == "" {
+			return nil, fmt.Errorf("instance_name in master_config must be set and unique")
+		}
+		if _, exists := change.newMap[name]; exists {
+			return nil, fmt.Errorf("duplicate instance_name %q found in master_config", name)
+		}
+		change.newMap[name] = config
+	}
+
+	newNames := make([]string, 0, len(change.newMap))
+	for name := range change.newMap {
+		newNames = append(newNames, name)
+	}
+	sort.Strings(newNames)
+	for _, name := range newNames {
+		if _, exists := change.oldMap[name]; !exists {
+			change.addedBlocks = append(change.addedBlocks, change.newMap[name])
+		}
+	}
+	oldNames := make([]string, 0, len(change.oldMap))
+	for name := range change.oldMap {
+		oldNames = append(oldNames, name)
+	}
+	sort.Strings(oldNames)
+	for _, name := range oldNames {
+		if _, exists := change.newMap[name]; !exists {
+			change.removedBlocks = append(change.removedBlocks, change.oldMap[name])
+		}
+	}
+
+	if len(change.addedBlocks) > 0 && len(change.removedBlocks) > 0 {
+		addedNames := make([]string, 0, len(change.addedBlocks))
+		for _, config := range change.addedBlocks {
+			addedNames = append(addedNames, config["instance_name"].(string))
+		}
+		removedNames := make([]string, 0, len(change.removedBlocks))
+		for _, config := range change.removedBlocks {
+			removedNames = append(removedNames, config["instance_name"].(string))
+		}
+		sort.Strings(removedNames)
+		return nil, fmt.Errorf("master_config: cannot add and remove blocks in the same apply (adding %v, removing %v). Split into two applies: scale out first, then scale in (or vice versa)", addedNames, removedNames)
+	}
+
+	inventoryChanged := len(change.addedBlocks) > 0 || len(change.removedBlocks) > 0
+	if name, field := masterConfigRetainedMutation(change.oldMap, change.newMap, inventoryChanged); field != "" {
+		return nil, fmt.Errorf("modifying field %q of existing master_config block %q is not supported. Please delete the block and add a new one instead", field, name)
+	}
+	return change, nil
+}
+
+func buildScaleOutMasterRequest(addedBlocks []map[string]interface{}, meta interface{}, vpcId string, projectId int64) ([]*tke.RunInstancesForNode, error) {
+	roleGroups := make(map[string][]map[string]interface{})
+	for _, block := range addedBlocks {
+		role := "MASTER_ETCD"
+		if value, ok := block["node_role"].(string); ok && value != "" {
+			role = value
+		}
+		roleGroups[role] = append(roleGroups[role], block)
+	}
+
+	roles := make([]string, 0, len(roleGroups))
+	for role := range roleGroups {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	runInstancesForNodeList := make([]*tke.RunInstancesForNode, 0, len(roles))
+	for _, role := range roles {
+		blocks := roleGroups[role]
+		runInstancesParaList := make([]*string, 0, len(blocks))
+		overrideSettings := make([]*tke.InstanceAdvancedSettings, 0, len(blocks))
+		hasInstanceOverrides := false
+		for _, block := range blocks {
+			paraJSON, _, err := tkeGetCvmRunInstancesPara(block, meta, vpcId, projectId)
+			if err != nil {
+				return nil, err
+			}
+			runInstancesParaList = append(runInstancesParaList, &paraJSON)
+
+			override, hasOverride, err := expandMasterConfigInstanceAdvancedSettings(block)
+			if err != nil {
+				return nil, err
+			}
+			overrideSettings = append(overrideSettings, &override)
+			hasInstanceOverrides = hasInstanceOverrides || hasOverride
+		}
+		if !hasInstanceOverrides {
+			overrideSettings = nil
+		}
+		nodeRole := role
+		runInstancesForNodeList = append(runInstancesForNodeList, &tke.RunInstancesForNode{
+			NodeRole:                          &nodeRole,
+			RunInstancesPara:                  runInstancesParaList,
+			InstanceAdvancedSettingsOverrides: overrideSettings,
+		})
+	}
+	return runInstancesForNodeList, nil
+}
+
+func buildScaleInMasterRequest(removedBlocks []map[string]interface{}) ([]*tke.ScaleInMaster, error) {
+	scaleInMasters := make([]*tke.ScaleInMaster, 0, len(removedBlocks))
+	for _, block := range removedBlocks {
+		instanceId, _ := block["instance_id"].(string)
+		instanceName, _ := block["instance_name"].(string)
+		if instanceId == "" {
+			return nil, fmt.Errorf("instance_id for master %q not found in state, cannot safely perform scale-in. Please refresh state or check configuration", instanceName)
+		}
+
+		role := "MASTER_ETCD"
+		if value, ok := block["node_role"].(string); ok && value != "" {
+			role = value
+		}
+		deleteMode := "terminate"
+		scaleInMasters = append(scaleInMasters, &tke.ScaleInMaster{
+			InstanceId:         &instanceId,
+			NodeRole:           &role,
+			InstanceDeleteMode: &deleteMode,
+		})
+	}
+	return scaleInMasters, nil
 }
 
 func TkeCvmCreateInfo() map[string]*schema.Schema {
@@ -3609,6 +4279,21 @@ func resourceTencentCloudTkeClusterCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	if clusterDeployType == TKE_DEPLOY_TYPE_INDEPENDENT {
+		masterConfigs, _ := d.Get("master_config").([]interface{})
+		expectedMasterCount := len(masterConfigs)
+		err = resource.Retry(10*readRetryTimeout, func() *resource.RetryError {
+			masters, _, inErr := service.DescribeClusterInstances(ctx, id)
+			if inErr != nil {
+				return retryError(inErr)
+			}
+			return masterInventoryConvergenceError(masters, expectedMasterCount, nil, masterInventoryGrowing, "master creation")
+		})
+		if err != nil {
+			return fmt.Errorf("cluster was created but its master inventory did not converge to %d healthy node(s): %w. Terraform will not delete or recreate control-plane nodes automatically; wait for TKE to stabilize and run Terraform again", expectedMasterCount, err)
+		}
+	}
+
 	if v, ok := helper.InterfacesHeadMap(d, "log_agent"); ok {
 		enabled := v["enabled"].(bool)
 		rootDir := v["kubelet_root_dir"].(string)
@@ -3798,6 +4483,7 @@ func resourceTencentCloudTkeClusterRead(d *schema.ResourceData, meta interface{}
 
 	_ = d.Set("worker_instances_list", workerInstancesList)
 
+	var masterHealthErr error
 	// 回读 master_config（仅 INDEPENDENT_CLUSTER）
 	if info.DeployType == TKE_DEPLOY_TYPE_INDEPENDENT {
 		masterInstanceIds := make([]*string, 0, len(masters))
@@ -3805,7 +4491,11 @@ func resourceTencentCloudTkeClusterRead(d *schema.ResourceData, meta interface{}
 			id := m.InstanceId
 			masterInstanceIds = append(masterInstanceIds, &id)
 		}
+		// An independent cluster cannot legitimately have zero masters. During
+		// creation the TKE instance list may briefly be empty, so keep the
+		// configured blocks until TKE exposes the authoritative instance set.
 		if len(masterInstanceIds) > 0 {
+			masterConfigs, _ := d.Get("master_config").([]interface{})
 			cvmService := CvmService{client: meta.(*TencentCloudClient).apiV3Conn}
 			var cvmInstances []*cvm.Instance
 			err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
@@ -3814,158 +4504,34 @@ func resourceTencentCloudTkeClusterRead(d *schema.ResourceData, meta interface{}
 				if inErr != nil {
 					return retryError(inErr)
 				}
+				if len(cvmInstances) != len(masterInstanceIds) {
+					return resource.RetryableError(fmt.Errorf("master_config: TKE returned %d masters but CVM returned %d instances", len(masterInstanceIds), len(cvmInstances)))
+				}
 				return nil
 			})
 			if err != nil {
-				log.Printf("[WARN] master_config: DescribeInstanceByFilter failed: %s", err.Error())
+				// Keep known configuration during transient CVM read/count mismatch.
+				// Import has no usable master state to preserve, so it must fail.
+				if len(masterConfigs) == 0 {
+					return err
+				}
+				log.Printf("[WARN] master_config: keeping existing state because CVM instances could not be read completely: %s", err.Error())
 			} else {
-				masterConfigs := d.Get("master_config").([]interface{})
-				if len(masterConfigs) > 0 && len(masterConfigs) == len(cvmInstances) {
-					// Existing state matches CVM count: match each block to its CVM instance
-					masterList := masterConfigs
-					for _, masterRaw := range masterList {
-						if master, ok := masterRaw.(map[string]interface{}); ok {
-							normalizeMasterConfigBlock(master)
-						}
-					}
-					// Build lookup maps
-					cvmById := make(map[string]*cvm.Instance)
-					for _, instance := range cvmInstances {
-						if instance != nil && instance.InstanceId != nil {
-							cvmById[*instance.InstanceId] = instance
-						}
-					}
-					cvmByName := make(map[string]*cvm.Instance)
-					for _, instance := range cvmInstances {
-						if instance != nil && instance.InstanceName != nil {
-							cvmByName[*instance.InstanceName] = instance
-						}
-					}
-
-					// Track which CVM instances have been matched
-					matched := make(map[string]bool)
-
-					// Round 1: match by instance_id (most reliable)
-					for _, mRaw := range masterList {
-						if mRaw == nil {
-							continue
-						}
-						m := mRaw.(map[string]interface{})
-						if existingId, _ := m["instance_id"].(string); existingId != "" {
-							if _, found := cvmById[existingId]; found {
-								matched[existingId] = true
-							}
-						}
-					}
-
-					// Round 2: for unmatched blocks, try instance_name then spec matching
-					for _, mRaw := range masterList {
-						if mRaw == nil {
-							continue
-						}
-						m := mRaw.(map[string]interface{})
-						existingId, _ := m["instance_id"].(string)
-						if existingId != "" && matched[existingId] {
-							// Already matched by id, keep it
-							continue
-						}
-
-						var matchedInstance *cvm.Instance
-
-						// Try instance_name match
-						if name, _ := m["instance_name"].(string); name != "" {
-							if inst, found := cvmByName[name]; found && !matched[*inst.InstanceId] {
-								matchedInstance = inst
-							}
-						}
-
-						// Try spec match (instance_type + subnet_id + zone) from remaining unmatched CVMs
-						if matchedInstance == nil {
-							instType, _ := m["instance_type"].(string)
-							subnetId, _ := m["subnet_id"].(string)
-							zone, _ := m["availability_zone"].(string)
-							for _, inst := range cvmInstances {
-								if inst == nil || inst.InstanceId == nil || matched[*inst.InstanceId] {
-									continue
-								}
-								if helper.PString(inst.InstanceType) == instType &&
-									helper.PString(inst.VirtualPrivateCloud.SubnetId) == subnetId &&
-									helper.PString(inst.Placement.Zone) == zone {
-									matchedInstance = inst
-									break
-								}
-							}
-						}
-
-						if matchedInstance != nil {
-							m["instance_id"] = *matchedInstance.InstanceId
-							matched[*matchedInstance.InstanceId] = true
-						} else {
-							m["instance_id"] = ""
-						}
-						normalizeMasterConfigBlock(m)
-					}
-					_ = d.Set("master_config", masterList)
-				} else {
-				// Import scenario: no master_config in state, build from CVM instances
-				masterList := make([]interface{}, 0, len(cvmInstances))
-				for _, instance := range cvmInstances {
-					mapping := map[string]interface{}{
-						"instance_charge_type_prepaid_period": 1,
-						"instance_type":                       helper.PString(instance.InstanceType),
-						"subnet_id":                           helper.PString(instance.VirtualPrivateCloud.SubnetId),
-						"availability_zone":                   helper.PString(instance.Placement.Zone),
-						"instance_name":                       helper.PString(instance.InstanceName),
-						"instance_charge_type":                helper.PString(instance.InstanceChargeType),
-						"system_disk_type":                    helper.PString(instance.SystemDisk.DiskType),
-						"system_disk_size":                    helper.PInt64(instance.SystemDisk.DiskSize),
-						"system_disk_pool_group":              "",
-						"internet_charge_type":                helper.PString(instance.InternetAccessible.InternetChargeType),
-						"internet_max_bandwidth_out":          helper.PInt64(instance.InternetAccessible.InternetMaxBandwidthOut),
-						"security_group_ids":                  helper.StringsInterfaces(instance.SecurityGroupIds),
-						"img_id":                              helper.PString(instance.ImageId),
-						"cam_role_name":                       "",
-						"desired_pod_num":                     DefaultDesiredPodNum,
-						"node_role":                           "MASTER_ETCD",
-						"enhanced_security_service":           true,
-						"enhanced_monitor_service":            true,
-						"enhanced_automation_service":         true,
-						"instance_id":                         helper.PString(instance.InstanceId),
-					}
-					if instance.RenewFlag != nil && helper.PString(instance.InstanceChargeType) == "PREPAID" {
-						mapping["instance_charge_type_prepaid_renew_flag"] = helper.PString(instance.RenewFlag)
-					} else {
-						mapping["instance_charge_type_prepaid_renew_flag"] = CVM_PREPAID_RENEW_FLAG_NOTIFY_AND_MANUAL_RENEW
-					}
-					if helper.PInt64(instance.InternetAccessible.InternetMaxBandwidthOut) > 0 {
-						mapping["public_ip_assigned"] = true
-					} else {
-						mapping["public_ip_assigned"] = false
-					}
-					if instance.CamRoleName != nil {
-						mapping["cam_role_name"] = helper.PString(instance.CamRoleName)
-					}
-					if instance.LoginSettings != nil && len(instance.LoginSettings.KeyIds) > 0 {
-						mapping["key_ids"] = helper.StringsInterfaces(instance.LoginSettings.KeyIds)
-					}
-						if instance.DisasterRecoverGroupId != nil && helper.PString(instance.DisasterRecoverGroupId) != "" {
-							mapping["disaster_recover_group_ids"] = []string{helper.PString(instance.DisasterRecoverGroupId)}
-						}
-						dataDisks := make([]interface{}, 0, len(instance.DataDisks))
-						for _, v := range instance.DataDisks {
-							dataDisk := map[string]interface{}{
-								"disk_type": helper.PString(v.DiskType),
-								"disk_size": helper.PInt64(v.DiskSize),
-							}
-							dataDisks = append(dataDisks, dataDisk)
-						}
-						mapping["data_disk"] = dataDisks
-						normalizeMasterConfigBlock(mapping)
-						masterList = append(masterList, mapping)
-					}
-					_ = d.Set("master_config", masterList)
+				masterList := reconcileMasterConfigState(masterConfigs, cvmInstances, masters)
+				if schemaErr := validateMasterConfigStateSchema(masterList); schemaErr != nil {
+					return schemaErr
+				}
+				if setErr := d.Set("master_config", masterList); setErr != nil {
+					return setErr
 				}
 			}
+		}
+		if len(masters) == 0 {
+			masterHealthErr = fmt.Errorf("TKE returned no master nodes for an independent cluster. Terraform kept the existing master_config state and will not submit a scaling request; wait for TKE inventory to recover or investigate the cluster before running Terraform again")
+		} else if info.ClusterStatus != "" && !strings.EqualFold(info.ClusterStatus, "Running") {
+			masterHealthErr = fmt.Errorf("TKE cluster is currently in %q. Terraform will not submit another master scaling request while the previous operation may still be converging; wait for the cluster and all masters to become healthy, then run Terraform again", info.ClusterStatus)
+		} else {
+			masterHealthErr = masterInstancesNotReadyError(masters)
 		}
 	}
 
@@ -4054,7 +4620,7 @@ func resourceTencentCloudTkeClusterRead(d *schema.ResourceData, meta interface{}
 
 		//_ = d.Set("node_pool_global_config", []map[string]interface{}{temp})
 	}
-	return nil
+	return masterHealthErr
 }
 
 func resourceTencentCloudTkeClusterUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -4329,170 +4895,63 @@ func resourceTencentCloudTkeClusterUpdate(d *schema.ResourceData, meta interface
 		newList := newM.([]interface{})
 
 		finalCount := len(newList)
-		if finalCount < 3 || finalCount > 7 {
-			return fmt.Errorf("TKE independent cluster master_config node count must be between 3 and 7, got %d", finalCount)
-		}
-
 		vpcId := d.Get("vpc_id").(string)
 		projectId := int64(d.Get("project_id").(int))
 
-		oldMap := make(map[string]map[string]interface{})
-		for _, item := range oldList {
-			if item == nil {
-				continue
-			}
-			m := item.(map[string]interface{})
-			name := m["instance_name"].(string)
-			if name == "" {
-				return fmt.Errorf("instance_name in master_config must be set and unique")
-			}
-			oldMap[name] = m
+		change, err := planMasterConfigInventoryChange(oldList, newList)
+		if err != nil {
+			return err
 		}
-
-		newMap := make(map[string]map[string]interface{})
-		for _, item := range newList {
-			if item == nil {
-				continue
-			}
-			m := item.(map[string]interface{})
-			name := m["instance_name"].(string)
-			if name == "" {
-				return fmt.Errorf("instance_name in master_config must be set and unique")
-			}
-			if _, exists := newMap[name]; exists {
-				return fmt.Errorf("duplicate instance_name %q found in master_config", name)
-			}
-			newMap[name] = m
-		}
-
-		var addedBlocks []map[string]interface{}
-		var removedBlocks []map[string]interface{}
-
-		// Sensitive fields (e.g. password) may report inconsistent values during
-		// plan even when the user has not changed anything, because the SDK
-		// masks their real value. Skip them to avoid false positives that would
-		// block legitimate scale-in/scale-out operations. Real user changes to
-		// these fields still require a delete-then-add flow.
-		skipFields := map[string]bool{
-			"instance_id": true,
-			"password":    true,
-		}
-
-		for name, newM := range newMap {
-			oldM, exists := oldMap[name]
-			if !exists {
-				addedBlocks = append(addedBlocks, newM)
-			} else {
-				for k, v := range newM {
-					if skipFields[k] {
-						continue
-					}
-					if masterConfigFieldsEquivalent(v, oldM[k]) {
-						continue
-					}
-					if !masterConfigValueEqual(v, oldM[k]) {
-						return fmt.Errorf("modifying existing master_config block %q is not supported. Please delete the block and add a new one instead", name)
-					}
-				}
-			}
-		}
-
-		for name, oldM := range oldMap {
-			if _, exists := newMap[name]; !exists {
-				removedBlocks = append(removedBlocks, oldM)
-			}
-		}
-
-		// Only allow one direction per apply: pure scale-out (all adds) or pure
-		// scale-in (all removes). Mixing them in a single apply almost always
-		// destroys a running master implicitly (e.g. rename, spec swap). Force
-		// the user to split it into two applies so the intent is explicit.
-		if len(addedBlocks) > 0 && len(removedBlocks) > 0 {
-			addedNames := make([]string, 0, len(addedBlocks))
-			for _, b := range addedBlocks {
-				addedNames = append(addedNames, b["instance_name"].(string))
-			}
-			removedNames := make([]string, 0, len(removedBlocks))
-			for _, b := range removedBlocks {
-				removedNames = append(removedNames, b["instance_name"].(string))
-			}
-			return fmt.Errorf("master_config: cannot add and remove blocks in the same apply (adding %v, removing %v). Split into two applies: scale out first, then scale in (or vice versa)", addedNames, removedNames)
-		}
+		oldMap := change.oldMap
+		newMap := change.newMap
+		addedBlocks := change.addedBlocks
+		removedBlocks := change.removedBlocks
 
 		// 1. Scale Out (Addition)
 		if len(addedBlocks) > 0 {
-			// Group added blocks by node_role
-			roleGroups := make(map[string][]map[string]interface{})
-			for _, block := range addedBlocks {
-				role := "MASTER_ETCD"
-				if nr, ok := block["node_role"].(string); ok && nr != "" {
-					role = nr
-				}
-				roleGroups[role] = append(roleGroups[role], block)
+			requiredInstanceIds, err := masterConfigInstanceIDs(oldList)
+			if err != nil {
+				return err
 			}
-
-			var runInstancesForNodeList []*tke.RunInstancesForNode
-			for role, blocks := range roleGroups {
-				runInstancesParaList := make([]*string, 0)
-				overrideSettings := make([]*tke.InstanceAdvancedSettings, 0, len(blocks))
-				hasInstanceOverrides := false
-				for _, block := range blocks {
-					paraJson, _, err := tkeGetCvmRunInstancesPara(block, meta, vpcId, projectId)
-					if err != nil {
-						return err
-					}
-					runInstancesParaList = append(runInstancesParaList, &paraJson)
-
-					override, hasOverride, err := expandMasterConfigInstanceAdvancedSettings(block)
-					if err != nil {
-						return err
-					}
-					overrideSettings = append(overrideSettings, &override)
-					hasInstanceOverrides = hasInstanceOverrides || hasOverride
-				}
-				if !hasInstanceOverrides {
-					overrideSettings = nil
-				}
-				nodeRole := role
-				runInstancesForNodeList = append(runInstancesForNodeList, &tke.RunInstancesForNode{
-					NodeRole:                          &nodeRole,
-					RunInstancesPara:                  runInstancesParaList,
-					InstanceAdvancedSettingsOverrides: overrideSettings,
-				})
-			}
-
-			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-				inErr := tkeService.ScaleOutClusterMaster(ctx, id, runInstancesForNodeList)
-				if inErr != nil {
-					return retryError(inErr)
-				}
-				return nil
-			})
+			alreadyAtTarget, err := readMasterScalingPreflight(ctx, tkeService, id, len(oldList), finalCount, requiredInstanceIds, "master scale-out")
 			if err != nil {
 				return err
 			}
 
-			// Poll and wait for all master nodes to be running
+			if !alreadyAtTarget {
+				runInstancesForNodeList, err := buildScaleOutMasterRequest(addedBlocks, meta, vpcId, projectId)
+				if err != nil {
+					return err
+				}
+
+				// ScaleOutClusterMaster has no idempotency token. Do not automatically
+				// retry an ambiguous response, because the first request may already
+				// have been accepted and a retry could create duplicate masters.
+				if err := tkeService.ScaleOutClusterMaster(ctx, id, runInstancesForNodeList); err != nil {
+					return fmt.Errorf("master scale-out request returned an error and its remote outcome is unknown: %w. Terraform did not retry the request; refresh TKE state before running Terraform again", err)
+				}
+			}
+
+			// ScaleOutClusterMaster only acknowledges an asynchronous operation.
+			// The remote cluster may now contain some or all requested masters. Keep
+			// full-state mode; a later Read reconciles remote IDs by stable identity
+			// even when Terraform Core cannot persist state after an update error.
+			d.Partial(false)
+
+			// Poll until the complete desired master inventory is visible and every
+			// node is running. Any non-running state may be an intermediate service
+			// state, so neither the state name nor its reason is treated as terminal
+			// while this request is converging. A persistent condition returns the
+			// last detailed status when the bounded wait expires.
 			err = resource.Retry(10*readRetryTimeout, func() *resource.RetryError {
 				masters, _, inErr := tkeService.DescribeClusterInstances(ctx, id)
 				if inErr != nil {
 					return retryError(inErr)
 				}
-				for _, m := range masters {
-					if m.InstanceRole != "MASTER_ETCD" {
-						continue
-					}
-					if m.InstanceState == "failed" {
-						return resource.NonRetryableError(fmt.Errorf("master node %s entered failed state: %s", m.InstanceId, m.FailedReason))
-					}
-					if m.InstanceState != "running" {
-						return resource.RetryableError(fmt.Errorf("master node %s is still %s", m.InstanceId, m.InstanceState))
-					}
-				}
-				return nil
+				return masterInventoryConvergenceError(masters, finalCount, requiredInstanceIds, masterInventoryGrowing, "master scale-out")
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("master scale-out did not converge to %d healthy node(s): %w. Terraform will not automatically delete/recreate masters or submit another scaling request; wait for TKE to become healthy, then run Terraform again so state is reconciled first", finalCount, err)
 			}
 
 			// After nodes reach running, wait for the cluster to exit MasterScaling so
@@ -4504,70 +4963,68 @@ func resourceTencentCloudTkeClusterUpdate(d *schema.ResourceData, meta interface
 				if inErr != nil {
 					return retryError(inErr)
 				}
-				if *status.ClusterState != "Running" {
+				if status == nil || status.ClusterState == nil {
+					return resource.RetryableError(fmt.Errorf("cluster %s has not reported a state after master scale-out", id))
+				}
+				if !strings.EqualFold(*status.ClusterState, "Running") {
 					return resource.RetryableError(fmt.Errorf("cluster %s still in %s after master scale-out, waiting for control plane to stabilize", id, *status.ClusterState))
 				}
 				return nil
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("all requested masters became healthy, but the cluster did not return to Running after scale-out: %w. Terraform will not submit another scaling request; wait for TKE control-plane convergence and run Terraform again", err)
 			}
 		}
 
 		// 2. Scale In (Deletion)
 		if len(removedBlocks) > 0 {
-			scaleInMasters := make([]*tke.ScaleInMaster, 0)
-			for _, block := range removedBlocks {
-				instId, _ := block["instance_id"].(string)
-				if instId == "" {
-					return fmt.Errorf("instance_id for master %q not found in state, cannot safely perform scale-in. Please refresh state or check configuration", block["instance_name"].(string))
+			// Computed values in a TypeList plan can remain positional after HCL
+			// removes a block. Resolve retained IDs from the old state by stable
+			// instance_name instead of trusting instance_id values in newList.
+			retainedStateBlocks := make([]interface{}, 0, len(newMap))
+			for name := range newMap {
+				if oldBlock, exists := oldMap[name]; exists {
+					retainedStateBlocks = append(retainedStateBlocks, oldBlock)
 				}
-
-				role := "MASTER_ETCD"
-				if nr, ok := block["node_role"].(string); ok && nr != "" {
-					role = nr
-				}
-				deleteMode := "terminate"
-
-				scaleInMasters = append(scaleInMasters, &tke.ScaleInMaster{
-					InstanceId:         &instId,
-					NodeRole:           &role,
-					InstanceDeleteMode: &deleteMode,
-				})
 			}
-
-			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-				inErr := tkeService.ScaleInClusterMaster(ctx, id, scaleInMasters)
-				if inErr != nil {
-					return retryError(inErr)
-				}
-				return nil
-			})
+			requiredInstanceIds, err := masterConfigInstanceIDs(retainedStateBlocks)
+			if err != nil {
+				return err
+			}
+			alreadyAtTarget, err := readMasterScalingPreflight(ctx, tkeService, id, len(oldList), finalCount, requiredInstanceIds, "master scale-in")
 			if err != nil {
 				return err
 			}
 
-			// Poll and wait for scaling down to complete
+			scaleInMasters, err := buildScaleInMasterRequest(removedBlocks)
+			if err != nil {
+				return err
+			}
+
+			if !alreadyAtTarget {
+				// As with scale-out, do not retry a mutating request whose remote
+				// outcome may be ambiguous.
+				if err := tkeService.ScaleInClusterMaster(ctx, id, scaleInMasters); err != nil {
+					return fmt.Errorf("master scale-in request returned an error and its remote outcome is unknown: %w. Terraform did not retry the request; refresh TKE state before running Terraform again", err)
+				}
+			}
+
+			// As with scale-out, the API acknowledgement means the remote state may
+			// already have changed even if the subsequent convergence check fails.
+			d.Partial(false)
+
+			// Wait for the exact retained inventory and for every retained master
+			// to be healthy. A removed node may temporarily report failed while TKE
+			// drains it, so presence is treated as pending rather than terminal.
 			err = resource.Retry(10*readRetryTimeout, func() *resource.RetryError {
 				masters, _, inErr := tkeService.DescribeClusterInstances(ctx, id)
 				if inErr != nil {
 					return retryError(inErr)
 				}
-				for _, block := range removedBlocks {
-					instId, _ := block["instance_id"].(string)
-					for _, m := range masters {
-						if m.InstanceId == instId {
-							if m.InstanceState == "failed" {
-								return resource.NonRetryableError(fmt.Errorf("master node %s scale-in failed: %s", instId, m.FailedReason))
-							}
-							return resource.RetryableError(fmt.Errorf("removed master node %s is still in cluster (state: %s)", instId, m.InstanceState))
-						}
-					}
-				}
-				return nil
+				return masterInventoryConvergenceError(masters, finalCount, requiredInstanceIds, masterInventoryShrinking, "master scale-in")
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("master scale-in did not converge to %d healthy node(s): %w. Terraform will not automatically retry the mutation or change the delete mode; wait for TKE to stabilize, then run Terraform again so state is reconciled first", finalCount, err)
 			}
 
 			// After nodes are removed from the instance list, the cluster stays in
@@ -4581,13 +5038,22 @@ func resourceTencentCloudTkeClusterUpdate(d *schema.ResourceData, meta interface
 				if inErr != nil {
 					return retryError(inErr)
 				}
-				if *status.ClusterState != "Running" {
+				if status == nil || status.ClusterState == nil {
+					return resource.RetryableError(fmt.Errorf("cluster %s has not reported a state after master scale-in", id))
+				}
+				if !strings.EqualFold(*status.ClusterState, "Running") {
 					return resource.RetryableError(fmt.Errorf("cluster %s still in %s after master scale-in, waiting for etcd metadata convergence", id, *status.ClusterState))
 				}
 				return nil
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("the retained masters became healthy, but the cluster did not return to Running after scale-in: %w. Terraform will not retry the mutation; wait for TKE control-plane convergence and run Terraform again", err)
+			}
+		}
+
+		if len(addedBlocks) > 0 || len(removedBlocks) > 0 {
+			if err := d.Set("master_config", masterConfigStateForInventoryChange(newList, oldMap)); err != nil {
+				return fmt.Errorf("reconciling master_config state after scaling: %w", err)
 			}
 		}
 	}

--- a/tencentcloud/resource_tc_tke_kubernetes_cluster_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_cluster_test.go
@@ -3,8 +3,8 @@ package tencentcloud
 import (
 	"context"
 	"fmt"
-	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
 	"log"
+	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
 	"testing"
 	"time"
 
@@ -666,7 +666,6 @@ resource "tencentcloudenterprise_tke_kubernetes_cluster" "managed_cluster" {
   }
 }`
 
-
 // TestAccTencentCloudTkeKubernetesClusterMasterScale creates an independent cluster,
 // then tests ScaleOut (3→5 masters) and ScaleIn (5→3 masters).
 func TestAccTencentCloudTkeKubernetesClusterMasterScale(t *testing.T) {
@@ -684,19 +683,31 @@ func TestAccTencentCloudTkeKubernetesClusterMasterScale(t *testing.T) {
 					resource.TestCheckResourceAttr("tencentcloudenterprise_tke_kubernetes_cluster.scale_test", "master_config.#", "3"),
 				),
 			},
-			// Step 2: ScaleOut - add 2 more MASTER_ETCD nodes (3→5)
+			// Step 2: ScaleOut - add 2 more MASTER_ETCD nodes (3→5).
+			// A new block is intentionally inserted at index 0 so Read must bind
+			// computed instance IDs by master identity rather than list position.
 			{
 				Config: testAccTkeIndependentClusterScaleOut,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tencentcloudenterprise_tke_kubernetes_cluster.scale_test", "master_config.#", "5"),
 				),
 			},
-			// Step 3: ScaleIn - remove 2 nodes back to 3
+			// Step 3: Re-planning after scale-out must not reshuffle master blocks.
+			{
+				Config:   testAccTkeIndependentClusterScaleOut,
+				PlanOnly: true,
+			},
+			// Step 4: ScaleIn - remove 2 nodes back to 3.
 			{
 				Config: testAccTkeIndependentCluster,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("tencentcloudenterprise_tke_kubernetes_cluster.scale_test", "master_config.#", "3"),
 				),
+			},
+			// Step 5: Re-planning after scale-in must also be idempotent.
+			{
+				Config:   testAccTkeIndependentCluster,
+				PlanOnly: true,
 			},
 		},
 	})
@@ -766,6 +777,17 @@ resource "tencentcloudenterprise_tke_kubernetes_cluster" "scale_test" {
   eni_subnet_ids          = ["subnet-ll9bvz02"]
 
   master_config {
+    instance_name     = "tf-scale-master-4"
+    instance_type     = "S5l.LARGE4"
+    subnet_id         = "subnet-ll9bvz02"
+    availability_zone = "kazakhstan-az1"
+    system_disk_type  = "CLOUD_SSD"
+    system_disk_size  = 50
+    security_group_ids = ["sg-9v7lwts0"]
+    password           = "Tencent@123"
+  }
+
+  master_config {
     instance_name     = "tf-scale-master-1"
     instance_type     = "S5l.LARGE4"
     subnet_id         = "subnet-ll9bvz02"
@@ -789,17 +811,6 @@ resource "tencentcloudenterprise_tke_kubernetes_cluster" "scale_test" {
 
   master_config {
     instance_name     = "tf-scale-master-3"
-    instance_type     = "S5l.LARGE4"
-    subnet_id         = "subnet-ll9bvz02"
-    availability_zone = "kazakhstan-az1"
-    system_disk_type  = "CLOUD_SSD"
-    system_disk_size  = 50
-    security_group_ids = ["sg-9v7lwts0"]
-    password           = "Tencent@123"
-  }
-
-  master_config {
-    instance_name     = "tf-scale-master-4"
     instance_type     = "S5l.LARGE4"
     subnet_id         = "subnet-ll9bvz02"
     availability_zone = "kazakhstan-az1"


### PR DESCRIPTION
## Summary

- preserve TKE master configuration identity across state refresh and list reordering
- reconcile master creation, scale-out, scale-in, import, and external changes consistently
- prevent scale-in from treating service-resolved defaults or omitted write-only values as master mutations
