### PR TITLE
feat(cic): support one-click role configuration deployment

### DIFF
--- a/docs/resources/tencentcloudenterprise_cic_provision_role_configuration_operation.md
+++ b/docs/resources/tencentcloudenterprise_cic_provision_role_configuration_operation.md
@@ -4,27 +4,37 @@ layout: "tencentcloudenterprise"
 page_title: "TencentCloudEnterprise: tencentcloudenterprise_cic_provision_role_configuration_operation"
 sidebar_current: "docs-tencentcloudenterprise-resource-cic_provision_role_configuration_operation"
 description: |-
-  Provides a resource to create a cic provision_role_configuration_operation
+  Provides a CIC permission configuration deployment operation. With no target
+arguments, the resource discovers the current identity center and deploys every
+permission configuration whose status is DeployedRequired.
 ---
 
 # tencentcloudenterprise_cic_provision_role_configuration_operation
 
-Provides a resource to create a cic provision_role_configuration_operation
+Provides a CIC permission configuration deployment operation. With no target
+arguments, the resource discovers the current identity center and deploys every
+permission configuration whose status is DeployedRequired.
+
+If automatic discovery finds no matching record, the operation succeeds and
+exports `provisioned_count = 0` without submitting a deployment task.
+
+`role_configuration_id`, `target_type`, and `target_uin` must either all be
+specified or all be omitted. Because this is an operation resource, Terraform
+runs it when the resource is created. Use `terraform apply -replace=...` to run
+the same configuration again.
 
 ## Example Usage
 
 ```hcl
-data "tencentcloudenterprise_cic_identity_center" "center" {}
+# Deploy every role configuration whose status is DeployedRequired.
+resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "all_required" {}
+```
 
-resource "tencentcloudenterprise_cic_role_configuration" "example" {
-  zone_id                 = data.tencentcloudenterprise_cic_identity_center.center.zone_id
-  role_configuration_name = "tf-provision-example"
-  description             = "tf example"
-}
+### # Deploy or redeploy one specific target
 
-resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "example" {
-  zone_id               = data.tencentcloudenterprise_cic_identity_center.center.zone_id
-  role_configuration_id = tencentcloudenterprise_cic_role_configuration.example.role_configuration_id
+```hcl
+resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "target" {
+  role_configuration_id = "rc-xxxxxxxxxxxx"
   target_type           = "MemberUin"
   target_uin            = 100001234567
 }
@@ -34,15 +44,21 @@ resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "ex
 
 The following arguments are supported:
 
-* `role_configuration_id` - (Required, String, ForceNew) Permission configuration ID.
-* `target_type` - (Required, String, ForceNew) Type of the synchronized target account of the Tencent Cloud Organization. ManagerUin: admin account; MemberUin: member account.
-* `target_uin` - (Required, Int, ForceNew) UIN of the target account of the Tencent Cloud Organization.
-* `zone_id` - (Required, String, ForceNew) Space ID.
+* `role_configuration_id` - (Optional, String, ForceNew) Permission configuration ID for a targeted deployment. Must be specified together with target_type and target_uin.
+* `target_type` - (Optional, String, ForceNew) Type of the synchronized target account for a targeted deployment. Valid values: ManagerUin and MemberUin. Must be specified together with role_configuration_id and target_uin.
+* `target_uin` - (Optional, Int, ForceNew) UIN of the target account for a targeted deployment. Must be specified together with role_configuration_id and target_type.
+* `zone_id` - (Optional, String, ForceNew) Space ID. If omitted, the provider reads it from the current CIC identity center.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the resource.
-
-
+* `provisioned_count` - Number of targets provisioned by this operation.
+* `provisioned` - Details of targets provisioned by this operation.
+  * `deployment_status` - Deployment status after this operation completes.
+  * `role_configuration_id` - Permission configuration ID deployed by this operation.
+  * `role_configuration_name` - Permission configuration name returned by CIC.
+  * `target_name` - Name of the target account returned by CIC.
+  * `target_type` - Type of the target account deployed by this operation.
+  * `target_uin` - UIN of the target account deployed by this operation.

--- a/docs/resources/tencentcloudenterprise_cic_provision_role_configuration_operation.md
+++ b/docs/resources/tencentcloudenterprise_cic_provision_role_configuration_operation.md
@@ -62,3 +62,4 @@ In addition to all arguments above, the following attributes are exported:
   * `target_name` - Name of the target account returned by CIC.
   * `target_type` - Type of the target account deployed by this operation.
   * `target_uin` - UIN of the target account deployed by this operation.
+

--- a/tencentcloud/resource_tc_cic_provision_role_configuration_operation.go
+++ b/tencentcloud/resource_tc_cic_provision_role_configuration_operation.go
@@ -1,23 +1,35 @@
 /*
-Provides a resource to create a cic provision_role_configuration_operation
+Provides a CIC permission configuration deployment operation. With no target
+arguments, the resource discovers the current identity center and deploys every
+permission configuration whose status is DeployedRequired.
 
-Example Usage
+If automatic discovery finds no matching record, the operation succeeds and
+exports `provisioned_count = 0` without submitting a deployment task.
+
+`role_configuration_id`, `target_type`, and `target_uin` must either all be
+specified or all be omitted. Because this is an operation resource, Terraform
+runs it when the resource is created. Use `terraform apply -replace=...` to run
+the same configuration again.
+
+# Example Usage
 
 ```hcl
-data "tencentcloudenterprise_cic_identity_center" "center" {}
 
-resource "tencentcloudenterprise_cic_role_configuration" "example" {
-  zone_id                 = data.tencentcloudenterprise_cic_identity_center.center.zone_id
-  role_configuration_name = "tf-provision-example"
-  description             = "tf example"
-}
+	# Deploy every role configuration whose status is DeployedRequired.
+	resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "all_required" {}
 
-resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "example" {
-  zone_id               = data.tencentcloudenterprise_cic_identity_center.center.zone_id
-  role_configuration_id = tencentcloudenterprise_cic_role_configuration.example.role_configuration_id
-  target_type           = "MemberUin"
-  target_uin            = 100001234567
-}
+```
+
+# Deploy or redeploy one specific target
+
+```hcl
+
+	resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "target" {
+	  role_configuration_id = "rc-xxxxxxxxxxxx"
+	  target_type           = "MemberUin"
+	  target_uin            = 100001234567
+	}
+
 ```
 */
 package tencentcloud
@@ -25,14 +37,16 @@ package tencentcloud
 import (
 	"context"
 	"fmt"
-	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
-	cic "terraform-provider-tencentcloudenterprise/sdk/cic/v20210331"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	cic "terraform-provider-tencentcloudenterprise/sdk/cic/v20210331"
+	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
 )
 
 func init() {
@@ -40,10 +54,12 @@ func init() {
 		TerraformTypeCN: "身份中心权限配置部署操作",
 		DescriptionCN:   "提供身份中心权限配置部署操作资源，用于将权限配置（重新）部署到成员账号。",
 		AttributesCN: map[string]string{
-			"zone_id":               "空间ID",
-			"role_configuration_id": "权限配置ID",
-			"target_type":           "目标账号类型",
-			"target_uin":            "目标账号UIN",
+			"zone_id":               "空间ID，不填写时自动读取身份中心空间",
+			"role_configuration_id": "权限配置ID；与目标类型、目标UIN同时填写时执行定向部署",
+			"target_type":           "目标账号类型；与权限配置ID、目标UIN同时填写时执行定向部署",
+			"target_uin":            "目标账号UIN；与权限配置ID、目标类型同时填写时执行定向部署",
+			"provisioned_count":     "本次部署的目标数量",
+			"provisioned":           "本次部署的目标明细",
 		},
 	})
 }
@@ -53,31 +69,87 @@ func resourceTencentCloudCicProvisionRoleConfigurationOperation() *schema.Resour
 		Create: resourceTencentCloudCicProvisionRoleConfigurationOperationCreate,
 		Read:   resourceTencentCloudCicProvisionRoleConfigurationOperationRead,
 		Delete: resourceTencentCloudCicProvisionRoleConfigurationOperationDelete,
-		Description: "Provide an identity center permission configuration provision operation resource to deploy or redeploy a role configuration to a member account.",
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			for _, name := range []string{"role_configuration_id", "target_type", "target_uin"} {
+				if !d.NewValueKnown(name) {
+					return nil
+				}
+			}
+			return validateCicProvisionRoleConfigurationOperationTarget(d)
+		},
+		Description: "Provide an identity center permission configuration provision operation resource. With no target arguments, it deploys every DeployedRequired record discovered from CIC. With a complete target, it deploys or redeploys that target.",
 		Schema: map[string]*schema.Schema{
 			"zone_id": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
-				Description: "Space ID.",
+				Description: "Space ID. If omitted, the provider reads it from the current CIC identity center.",
 			},
 			"role_configuration_id": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
-				Description: "Permission configuration ID.",
+				Description: "Permission configuration ID for a targeted deployment. Must be specified together with target_type and target_uin.",
 			},
 			"target_type": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Type of the synchronized target account of the Tencent Cloud Organization. ManagerUin: admin account; MemberUin: member account.",
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ManagerUin",
+					"MemberUin",
+				}, false),
+				Description: "Type of the synchronized target account for a targeted deployment. Valid values: ManagerUin and MemberUin. Must be specified together with role_configuration_id and target_uin.",
 			},
 			"target_uin": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+				Description:  "UIN of the target account for a targeted deployment. Must be specified together with role_configuration_id and target_type.",
+			},
+			"provisioned_count": {
 				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
-				Description: "UIN of the target account of the Tencent Cloud Organization.",
+				Computed:    true,
+				Description: "Number of targets provisioned by this operation.",
+			},
+			"provisioned": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Details of targets provisioned by this operation.",
+				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+					"role_configuration_id": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Permission configuration ID deployed by this operation.",
+					},
+					"role_configuration_name": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Permission configuration name returned by CIC.",
+					},
+					"target_type": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Type of the target account deployed by this operation.",
+					},
+					"target_uin": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "UIN of the target account deployed by this operation.",
+					},
+					"target_name": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Name of the target account returned by CIC.",
+					},
+					"deployment_status": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Deployment status after this operation completes.",
+					},
+				}},
 			},
 		},
 	}
@@ -90,36 +162,173 @@ func resourceTencentCloudCicProvisionRoleConfigurationOperationCreate(d *schema.
 	logId := getLogId(contextNil)
 	ctx := context.WithValue(context.Background(), logIdKey, logId)
 
-	var (
-		zoneId              string
-		roleConfigurationId string
-		targetType          string
-		targetUin           int
-		request             = cic.NewProvisionRoleConfigurationRequest()
-		response            = cic.NewProvisionRoleConfigurationResponse()
-	)
+	client := meta.(*TencentCloudClient)
+	service := CicService{client: client.apiV3Conn}
+	if err := validateCicProvisionRoleConfigurationOperationTarget(d); err != nil {
+		return err
+	}
 
-	if v, ok := d.GetOk("zone_id"); ok {
-		zoneId = v.(string)
-		request.ZoneId = helper.String(zoneId)
+	zoneId := ""
+	if value, ok := d.GetOk("zone_id"); ok {
+		zoneId = value.(string)
+	} else {
+		identityCenter, err := service.DescribeCicIdentityCenter(ctx)
+		if err != nil {
+			return fmt.Errorf("describe CIC identity center failed: %w", err)
+		}
+		if identityCenter == nil || identityCenter.Response == nil || identityCenter.Response.ZoneId == nil || *identityCenter.Response.ZoneId == "" {
+			return fmt.Errorf("CIC identity center returned an empty space ID")
+		}
+		zoneId = *identityCenter.Response.ZoneId
+		if err := d.Set("zone_id", zoneId); err != nil {
+			return fmt.Errorf("set CIC space ID failed: %w", err)
+		}
 	}
-	if v, ok := d.GetOk("role_configuration_id"); ok {
-		roleConfigurationId = v.(string)
-		request.RoleConfigurationId = helper.String(roleConfigurationId)
+
+	roleConfigurationId, roleConfigurationIdSet := getCicProvisionOperationString(d, "role_configuration_id")
+	targetType, targetTypeSet := getCicProvisionOperationString(d, "target_type")
+	targetUinValue, targetUinSet := d.GetOk("target_uin")
+	explicitTarget := roleConfigurationIdSet && targetTypeSet && targetUinSet
+
+	// An explicit target preserves the original single-operation behavior. With
+	// no target arguments, mirror the CIC console's one-click flow and discover
+	// only records whose status is DeployedRequired.
+	targets := make([]*cic.RoleConfigurationProvisionings, 0)
+	if explicitTarget {
+		targets = append(targets, &cic.RoleConfigurationProvisionings{
+			RoleConfigurationId: helper.String(roleConfigurationId),
+			TargetType:          helper.String(targetType),
+			TargetUin:           helper.IntInt64(targetUinValue.(int)),
+		})
+	} else {
+		var provisionings []*cic.RoleConfigurationProvisionings
+		err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
+			result, e := service.ListCicRoleConfigurationProvisionings(ctx, zoneId, "DeployedRequired", "", "", 0)
+			if e != nil {
+				return retryError(e)
+			}
+			provisionings = result
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("list CIC role configuration provisionings with status %q failed: %w", "DeployedRequired", err)
+		}
+		targets = append(targets, provisionings...)
 	}
-	if v, ok := d.GetOk("target_type"); ok {
-		targetType = v.(string)
-		request.TargetType = helper.String(targetType)
+
+	uniqueTargets := make([]*cic.RoleConfigurationProvisionings, 0, len(targets))
+	seenTargets := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		key := cicProvisioningTargetKey(target)
+		if _, exists := seenTargets[key]; exists {
+			continue
+		}
+		seenTargets[key] = struct{}{}
+		uniqueTargets = append(uniqueTargets, target)
 	}
-	if v, ok := d.GetOkExists("target_uin"); ok {
-		targetUin = v.(int)
-		request.TargetUin = helper.IntInt64(targetUin)
+	targets = uniqueTargets
+
+	// The list endpoint normally returns a stable order, but sorting makes the
+	// Terraform ID and state deterministic across refreshes and pages.
+	sort.SliceStable(targets, func(i, j int) bool {
+		return cicProvisioningTargetKey(targets[i]) < cicProvisioningTargetKey(targets[j])
+	})
+
+	provisioned := make([]map[string]interface{}, 0, len(targets))
+	ids := []string{zoneId}
+	for _, target := range targets {
+		if target == nil || target.TargetUin == nil || *target.TargetUin <= 0 {
+			return fmt.Errorf("CIC role configuration provisioning returned an invalid target UIN")
+		}
+		provisioningRoleConfigurationId := roleConfigurationId
+		if target.RoleConfigurationId != nil && *target.RoleConfigurationId != "" {
+			provisioningRoleConfigurationId = *target.RoleConfigurationId
+		}
+		provisioningTargetType := targetType
+		if target.TargetType != nil && *target.TargetType != "" {
+			provisioningTargetType = *target.TargetType
+		}
+		if provisioningRoleConfigurationId == "" || provisioningTargetType == "" {
+			return fmt.Errorf("CIC role configuration provisioning returned an incomplete target")
+		}
+		if err := provisionCicRoleConfiguration(ctx, client, zoneId, provisioningRoleConfigurationId, provisioningTargetType, *target.TargetUin); err != nil {
+			return fmt.Errorf("provision CIC role configuration %s to target %s#%d failed: %w", provisioningRoleConfigurationId, provisioningTargetType, *target.TargetUin, err)
+		}
+
+		entry := map[string]interface{}{
+			"role_configuration_id": provisioningRoleConfigurationId,
+			"target_type":           provisioningTargetType,
+			"target_uin":            *target.TargetUin,
+		}
+		if target.RoleConfigurationName != nil {
+			entry["role_configuration_name"] = *target.RoleConfigurationName
+		}
+		if target.TargetName != nil {
+			entry["target_name"] = *target.TargetName
+		}
+		entry["deployment_status"] = "Deployed"
+		provisioned = append(provisioned, entry)
+		ids = append(ids, cicProvisioningTargetKey(target))
 	}
+
+	_ = d.Set("provisioned_count", len(provisioned))
+	_ = d.Set("provisioned", provisioned)
+	if explicitTarget {
+		d.SetId(strings.Join([]string{zoneId, roleConfigurationId, targetType, helper.IntToStr(targetUinValue.(int))}, FILED_SP))
+	} else {
+		d.SetId(helper.DataResourceIdsHash(ids))
+	}
+	return resourceTencentCloudCicProvisionRoleConfigurationOperationRead(d, meta)
+}
+
+type cicProvisionOperationSchemaGetter interface {
+	GetOk(string) (interface{}, bool)
+}
+
+func validateCicProvisionRoleConfigurationOperationTarget(d cicProvisionOperationSchemaGetter) error {
+	_, roleConfigurationIdSet := getCicProvisionOperationString(d, "role_configuration_id")
+	_, targetTypeSet := getCicProvisionOperationString(d, "target_type")
+	_, targetUinSet := d.GetOk("target_uin")
+	setCount := 0
+	for _, set := range []bool{roleConfigurationIdSet, targetTypeSet, targetUinSet} {
+		if set {
+			setCount++
+		}
+	}
+	if setCount != 0 && setCount != 3 {
+		return fmt.Errorf("role_configuration_id, target_type, and target_uin must either all be specified for a targeted deployment or all be omitted for automatic DeployedRequired deployment")
+	}
+	return nil
+}
+
+func getCicProvisionOperationString(d cicProvisionOperationSchemaGetter, name string) (string, bool) {
+	value, ok := d.GetOk(name)
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	return text, ok && text != ""
+}
+
+// provisionCicRoleConfiguration submits one deployment operation and waits for
+// its asynchronous CIC task to finish. Keeping this in one helper ensures the
+// explicit-UIN and auto-discovery paths have identical retry and failure logic.
+func provisionCicRoleConfiguration(ctx context.Context, client *TencentCloudClient, zoneId, roleConfigurationId, targetType string, targetUin int64) error {
+	logId := getLogId(ctx)
+	request := cic.NewProvisionRoleConfigurationRequest()
+	request.ZoneId = helper.String(zoneId)
+	request.RoleConfigurationId = helper.String(roleConfigurationId)
+	request.TargetType = helper.String(targetType)
+	request.TargetUin = helper.Int64(targetUin)
+	var response *cic.ProvisionRoleConfigurationResponse
 
 	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-		result, e := meta.(*TencentCloudClient).apiV3Conn.UseCicClient().ProvisionRoleConfiguration(request)
+		result, e := client.apiV3Conn.UseCicClient().ProvisionRoleConfiguration(request)
 		if e != nil {
 			return retryError(e)
+		}
+		if result == nil || result.Response == nil || result.Response.Task == nil || result.Response.Task.TaskId == nil {
+			return resource.NonRetryableError(fmt.Errorf("CIC returned no provisioning task"))
 		}
 		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
 			logId, request.GetAction(), request.ToJsonString(), result.ToJsonString())
@@ -127,29 +336,51 @@ func resourceTencentCloudCicProvisionRoleConfigurationOperationCreate(d *schema.
 		return nil
 	})
 	if err != nil {
-		log.Printf("[CRITAL]%s create cic provision role configuration operation failed, reason:%+v", logId, err)
 		return err
 	}
 
-	if response.Response == nil || response.Response.Task == nil || response.Response.Task.TaskId == nil {
-		return fmt.Errorf("can not find taskId")
-	}
-
-	service := CicService{client: meta.(*TencentCloudClient).apiV3Conn}
+	service := CicService{client: client.apiV3Conn}
 	taskId := *response.Response.Task.TaskId
-	if _, err := (&resource.StateChangeConf{
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
-		Pending:    []string{"InProgress", ""},
-		Refresh:    service.AssignmentTaskStatusStateRefreshFunc(zoneId, taskId, []string{"Failed"}),
-		Target:     []string{"Success"},
-		Timeout:    600 * time.Second,
-	}).WaitForStateContext(ctx); err != nil {
+	conf := BuildStateChangeConf([]string{"InProgress", ""}, []string{"Success", "Failed"}, 600*time.Second, 5*time.Second,
+		service.AssignmentTaskStatusStateRefreshFunc(zoneId, taskId, []string{"Failed"}))
+	object, err := conf.WaitForStateContext(ctx)
+	if err != nil {
 		return err
 	}
+	taskStatus, ok := object.(*cic.TaskStatus)
+	if !ok || taskStatus == nil || taskStatus.Status == nil {
+		return fmt.Errorf("CIC provisioning task %s returned an empty status", taskId)
+	}
+	if *taskStatus.Status == "Failed" {
+		reason := ""
+		if taskStatus.FailureReason != nil {
+			reason = *taskStatus.FailureReason
+		}
+		if reason != "" {
+			return fmt.Errorf("CIC provisioning task %s failed: %s", taskId, reason)
+		}
+		return fmt.Errorf("CIC provisioning task %s failed", taskId)
+	}
+	return nil
+}
 
-	d.SetId(strings.Join([]string{zoneId, roleConfigurationId, targetType, helper.IntToStr(targetUin)}, FILED_SP))
-	return resourceTencentCloudCicProvisionRoleConfigurationOperationRead(d, meta)
+func cicProvisioningTargetKey(target *cic.RoleConfigurationProvisionings) string {
+	if target == nil {
+		return "<nil>"
+	}
+	roleConfigurationId := ""
+	if target.RoleConfigurationId != nil {
+		roleConfigurationId = *target.RoleConfigurationId
+	}
+	targetType := ""
+	if target.TargetType != nil {
+		targetType = *target.TargetType
+	}
+	targetUin := int64(0)
+	if target.TargetUin != nil {
+		targetUin = *target.TargetUin
+	}
+	return strings.Join([]string{roleConfigurationId, targetType, helper.Int64ToStr(targetUin)}, FILED_SP)
 }
 
 func resourceTencentCloudCicProvisionRoleConfigurationOperationRead(d *schema.ResourceData, meta interface{}) error {

--- a/tencentcloud/resource_tc_cic_provision_role_configuration_operation_test.go
+++ b/tencentcloud/resource_tc_cic_provision_role_configuration_operation_test.go
@@ -1,70 +1,115 @@
 package tencentcloud
 
 import (
-	"fmt"
+	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	cic "terraform-provider-tencentcloudenterprise/sdk/cic/v20210331"
 )
 
+func TestCicProvisionRoleConfigurationOperationSchema(t *testing.T) {
+	operationResource := resourceTencentCloudCicProvisionRoleConfigurationOperation()
+	if err := operationResource.InternalValidate(nil, true); err != nil {
+		t.Fatalf("resource schema validation failed: %v", err)
+	}
+	resourceSchema := operationResource.Schema
+	for _, name := range []string{"zone_id", "role_configuration_id", "target_type", "target_uin"} {
+		field, ok := resourceSchema[name]
+		if !ok {
+			t.Fatalf("schema field %q is missing", name)
+		}
+		if !field.Optional {
+			t.Fatalf("schema field %q must be optional", name)
+		}
+	}
+	if !resourceSchema["zone_id"].Computed {
+		t.Fatal("zone_id must be computed when it is discovered automatically")
+	}
+	if _, ok := resourceSchema["deployment_status"]; ok {
+		t.Fatal("deployment_status must not be exposed as a resource argument")
+	}
+	for _, name := range []string{"provisioned_count", "provisioned"} {
+		if field := resourceSchema[name]; field == nil || !field.Computed {
+			t.Fatalf("schema field %q must be computed", name)
+		}
+	}
+}
+
+func TestValidateCicProvisionRoleConfigurationOperationTarget(t *testing.T) {
+	resourceSchema := resourceTencentCloudCicProvisionRoleConfigurationOperation().Schema
+	tests := []struct {
+		name    string
+		values  map[string]interface{}
+		wantErr bool
+	}{
+		{name: "automatic deployment", values: map[string]interface{}{}},
+		{name: "targeted deployment", values: map[string]interface{}{
+			"role_configuration_id": "rc-test",
+			"target_type":           "MemberUin",
+			"target_uin":            110000000001,
+		}},
+		{name: "role only", values: map[string]interface{}{"role_configuration_id": "rc-test"}, wantErr: true},
+		{name: "target type only", values: map[string]interface{}{"target_type": "MemberUin"}, wantErr: true},
+		{name: "target uin only", values: map[string]interface{}{"target_uin": 110000000001}, wantErr: true},
+		{name: "missing target uin", values: map[string]interface{}{
+			"role_configuration_id": "rc-test",
+			"target_type":           "MemberUin",
+		}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceSchema, tt.values)
+			err := validateCicProvisionRoleConfigurationOperationTarget(d)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validate target error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCicProvisioningTargetKey(t *testing.T) {
+	roleConfigurationID := "rc-test"
+	memberType := "MemberUin"
+	memberUin := int64(110000000001)
+	target := &cic.RoleConfigurationProvisionings{RoleConfigurationId: &roleConfigurationID, TargetType: &memberType, TargetUin: &memberUin}
+	if got, want := cicProvisioningTargetKey(target), "rc-test#MemberUin#110000000001"; got != want {
+		t.Fatalf("unexpected provisioning target key: got %q, want %q", got, want)
+	}
+}
+
 func TestAccTencentCloudCicProvisionRoleConfigurationOperationResource_basic(t *testing.T) {
-	t.Parallel()
-	suffix := acctest.RandString(6)
-	const (
-		existingRoleConfigurationId = "rc-xxxxxx"
-		existingTargetUin           = "100001234567"
-	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCicProvisionRoleConfigurationOperation(suffix, existingRoleConfigurationId, existingTargetUin),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("tencentcloudenterprise_cic_provision_role_configuration_operation.example", "id"),
-					resource.TestCheckResourceAttrSet("tencentcloudenterprise_cic_provision_role_configuration_operation.example", "zone_id"),
-					resource.TestCheckResourceAttr("tencentcloudenterprise_cic_provision_role_configuration_operation.example", "role_configuration_id", existingRoleConfigurationId),
-					resource.TestCheckResourceAttr("tencentcloudenterprise_cic_provision_role_configuration_operation.example", "target_type", "MemberUin"),
-					resource.TestCheckResourceAttr("tencentcloudenterprise_cic_provision_role_configuration_operation.example", "target_uin", existingTargetUin),
-				),
+				Config: testAccCicProvisionRoleConfigurationOperation,
+				Check:  resource.ComposeTestCheckFunc(testAccCicProvisionRoleConfigurationOperationChecks()...),
 			},
 		},
 	})
 }
 
-func testAccCicProvisionRoleConfigurationOperation(suffix, roleConfigurationId, targetUin string) string {
-	return fmt.Sprintf(`
-data "tencentcloudenterprise_cic_identity_center" "center" {}
-
-resource "tencentcloudenterprise_cic_role_configuration_permission_custom_policy_attachment" "example" {
-  zone_id               = data.tencentcloudenterprise_cic_identity_center.center.zone_id
-  role_configuration_id = "%s"
-  role_policy_name      = "TfProvisionCustomPolicy%s"
-  role_policy_document  = <<-EOF
-{
-  "version": "2.0",
-  "statement": [
-    {
-      "effect": "allow",
-      "action": [
-        "vpc:DescribeVpcs"
-      ],
-      "resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
+func testAccCicProvisionRoleConfigurationOperationChecks() []resource.TestCheckFunc {
+	const resourceName = "tencentcloudenterprise_cic_provision_role_configuration_operation.example"
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
+		resource.TestCheckResourceAttrSet(resourceName, "provisioned_count"),
+	}
+	if expected := os.Getenv("TCE_CIC_ACC_EXPECTED_PROVISIONED_COUNT"); expected != "" {
+		checks = append(checks, resource.TestCheckResourceAttr(resourceName, "provisioned_count", expected))
+		if expected != "0" {
+			checks = append(checks, resource.TestCheckResourceAttr(resourceName, "provisioned.0.deployment_status", "Deployed"))
+		}
+	}
+	return checks
 }
 
+const testAccCicProvisionRoleConfigurationOperation = `
 resource "tencentcloudenterprise_cic_provision_role_configuration_operation" "example" {
-  zone_id               = data.tencentcloudenterprise_cic_identity_center.center.zone_id
-  role_configuration_id = "%s"
-  target_type           = "MemberUin"
-  target_uin            = %s
-  depends_on            = [tencentcloudenterprise_cic_role_configuration_permission_custom_policy_attachment.example]
 }
-`, roleConfigurationId, suffix, roleConfigurationId, targetUin)
-}
+`

--- a/tencentcloud/service_tencentcloud_cic.go
+++ b/tencentcloud/service_tencentcloud_cic.go
@@ -20,6 +20,48 @@ type CicService struct {
 	client *connectivity.TencentCloudClient
 }
 
+func (me *CicService) ListCicRoleConfigurationProvisionings(ctx context.Context, zoneId, deploymentStatus, roleConfigurationId, targetType string, targetUin int64) (ret []*cic.RoleConfigurationProvisionings, errRet error) {
+	logId := getLogId(ctx)
+	nextToken := ""
+
+	for {
+		request := cic.NewListRoleConfigurationProvisioningsRequest()
+		request.ZoneId = helper.String(zoneId)
+		request.DeploymentStatus = helper.String(deploymentStatus)
+		request.MaxResults = helper.Int64(100)
+		if nextToken != "" {
+			request.NextToken = helper.String(nextToken)
+		}
+		if roleConfigurationId != "" {
+			request.RoleConfigurationId = helper.String(roleConfigurationId)
+		}
+		if targetType != "" {
+			request.TargetType = helper.String(targetType)
+		}
+		if targetUin > 0 {
+			request.TargetUin = helper.Int64(targetUin)
+		}
+
+		ratelimit.Check(request.GetAction())
+		response, err := me.client.UseCicClient().ListRoleConfigurationProvisionings(request)
+		if err != nil {
+			errRet = err
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n", logId, request.GetAction(), request.ToJsonString(), err.Error())
+			return
+		}
+		if response == nil || response.Response == nil {
+			log.Printf("[DEBUG]%s api[%s] returned an empty response, request body [%s]\n", logId, request.GetAction(), request.ToJsonString())
+			return ret, nil
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n", logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+		ret = append(ret, response.Response.RoleConfigurationProvisionings...)
+		if response.Response.IsTruncated == nil || !*response.Response.IsTruncated || response.Response.NextToken == nil || *response.Response.NextToken == "" {
+			return ret, nil
+		}
+		nextToken = *response.Response.NextToken
+	}
+}
+
 func (me *CicService) DescribeCicIdentityCenter(ctx context.Context) (ret *cic.DescribeIdentityCenterResponse, errRet error) {
 	logId := getLogId(ctx)
 


### PR DESCRIPTION
## Summary

- allow CIC role configuration deployment with no required input arguments
- automatically deploy all `DeployedRequired` targets while preserving explicit target deployment
- expose provisioned target details and document repeat execution
