### PR TITLE
fix(provider): correct VPCDNS tags and prevent CIC read panic

### DIFF
--- a/tencentcloud/resource_tc_cic_role_configuration_permission_policy_attachment.go
+++ b/tencentcloud/resource_tc_cic_role_configuration_permission_policy_attachment.go
@@ -216,37 +216,36 @@ func resourceTencentCloudCicRoleConfigurationPermissionPolicyAttachmentRead(d *s
 		return err
 	}
 
-	if respData == nil {
-		d.SetId("")
-		log.Printf("[WARN]%s resource `cic_role_configuration_permission_policy_attachment` [%s] not found, please check if it has been deleted.\n", logId, d.Id())
-		return nil
-	}
-
-	if respData.RolePolicies != nil {
-		var rolePolicie *cic.RolePolicie
-		for _, r := range respData.RolePolicies {
-			if *r.RolePolicyId == rolePolicyId {
-				rolePolicie = r
+	var rolePolicy *cic.RolePolicie
+	if respData != nil {
+		for _, candidate := range respData.RolePolicies {
+			if candidate != nil && candidate.RolePolicyId != nil && *candidate.RolePolicyId == rolePolicyId {
+				rolePolicy = candidate
 				break
 			}
 		}
+	}
+	if rolePolicy == nil {
+		attachmentID := d.Id()
+		d.SetId("")
+		log.Printf("[WARN]%s resource `cic_role_configuration_permission_policy_attachment` [%s] not found, please check if it has been deleted.\n", logId, attachmentID)
+		return nil
+	}
 
-		if rolePolicie.RolePolicyName != nil {
-			_ = d.Set("role_policy_name", rolePolicie.RolePolicyName)
-		}
+	if rolePolicy.RolePolicyName != nil {
+		_ = d.Set("role_policy_name", rolePolicy.RolePolicyName)
+	}
 
-		if rolePolicie.RolePolicyType != nil {
-			_ = d.Set("role_policy_type", rolePolicie.RolePolicyType)
-		}
+	if rolePolicy.RolePolicyType != nil {
+		_ = d.Set("role_policy_type", rolePolicy.RolePolicyType)
+	}
 
-		if rolePolicie.RolePolicyDocument != nil {
-			_ = d.Set("role_policy_document", rolePolicie.RolePolicyDocument)
-		}
+	if rolePolicy.RolePolicyDocument != nil {
+		_ = d.Set("role_policy_document", rolePolicy.RolePolicyDocument)
+	}
 
-		if rolePolicie.AddTime != nil {
-			_ = d.Set("add_time", rolePolicie.AddTime)
-		}
-
+	if rolePolicy.AddTime != nil {
+		_ = d.Set("add_time", rolePolicy.AddTime)
 	}
 
 	return nil

--- a/tencentcloud/resource_tc_vpcdns_zone.go
+++ b/tencentcloud/resource_tc_vpcdns_zone.go
@@ -40,12 +40,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 
 	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
 
-	vpcdns "terraform-provider-tencentcloudenterprise/sdk/vpcdns/v20191025"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	vpcdns "terraform-provider-tencentcloudenterprise/sdk/vpcdns/v20191025"
 )
 
 func resourceTencentCloudVpcDnsZone() *schema.Resource {
@@ -242,12 +243,22 @@ func resourceTencentCloudVpcDnsZoneCreate(d *schema.ResourceData, meta interface
 	id := *response.Response.ZoneId
 	d.SetId(id)
 
-	client := meta.(*TencentCloudClient).apiV3Conn
-	tagService := TagService{client: client}
-	region := client.Region
-
 	if tags := helper.GetTags(d, "tags"); len(tags) > 0 {
-		resourceName := BuildTagResourceName("privatedns", "zone", region, id)
+		client := meta.(*TencentCloudClient).apiV3Conn
+		service := VpcDnsService{client: client}
+		zone, err := service.DescribeVpcDnsZoneById(ctx, id)
+		if err != nil {
+			return err
+		}
+		if zone == nil {
+			return fmt.Errorf("private zone %s not found after creation", id)
+		}
+
+		resourceName, err := buildVpcDnsZoneTagResourceName(zone, client.Region)
+		if err != nil {
+			return err
+		}
+		tagService := TagService{client: client}
 		if err := tagService.ModifyTags(ctx, resourceName, tags, nil); err != nil {
 			return err
 		}
@@ -264,27 +275,20 @@ func resourceTencentCloudVpcDnsZoneRead(d *schema.ResourceData, meta interface{}
 	ctx := context.WithValue(context.TODO(), logIdKey, logId)
 
 	id := d.Id()
-
-	request := vpcdns.NewDescribePrivateZoneRequest()
-	request.ZoneId = helper.String(id)
-
-	var response *vpcdns.DescribePrivateZoneResponse
-
-	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
-		result, e := meta.(*TencentCloudClient).apiV3Conn.UseVpcDnsClient().DescribePrivateZone(request)
-		if e != nil {
-			return retryError(e)
-		}
-
-		response = result
-		return nil
-	})
+	client := meta.(*TencentCloudClient).apiV3Conn
+	service := VpcDnsService{client: client}
+	info, err := service.DescribeVpcDnsZoneById(ctx, id)
 	if err != nil {
-		log.Printf("[CRITAL]%s read DnsPod Domain failed, reason:%s\n", logId, err.Error())
 		return err
 	}
-
-	info := response.Response.PrivateZone
+	if info == nil {
+		log.Printf("[WARN]%s resource `tencentcloudenterprise_vpcdns_zone` [%s] not found, please check if it has been deleted.\n", logId, id)
+		d.SetId("")
+		return nil
+	}
+	if info.ZoneId == nil {
+		return fmt.Errorf("private zone %s has no ZoneId", id)
+	}
 	d.SetId(*info.ZoneId)
 
 	_ = d.Set("domain", info.Domain)
@@ -298,11 +302,12 @@ func resourceTencentCloudVpcDnsZoneRead(d *schema.ResourceData, meta interface{}
 	}
 	_ = d.Set("tag_set", tagSets)
 
-	client := meta.(*TencentCloudClient).apiV3Conn
 	tagService := TagService{client: client}
-	region := client.Region
-
-	tags, err := tagService.DescribeResourceTags(ctx, "privatedns", "zone", region, id)
+	tagResourceID, err := vpcDnsZoneTagResourceID(info)
+	if err != nil {
+		return err
+	}
+	tags, err := tagService.DescribeResourceTags(ctx, VPCDNS_SERVICE_TYPE, VPCDNS_RESOURCE_TYPE, client.Region, tagResourceID)
 	if err != nil {
 		return err
 	}
@@ -413,15 +418,24 @@ func resourceTencentCloudVpcDnsZoneUpdate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("tag_set do not support change, please use tags instead.")
 	}
 
-	client := meta.(*TencentCloudClient).apiV3Conn
-	tagService := TagService{client: client}
-	region := client.Region
-
 	if d.HasChange("tags") {
 		oldTags, newTags := d.GetChange("tags")
 		replaceTags, deleteTags := diffTags(oldTags.(map[string]interface{}), newTags.(map[string]interface{}))
 
-		resourceName := BuildTagResourceName("privatedns", "zone", region, id)
+		client := meta.(*TencentCloudClient).apiV3Conn
+		service := VpcDnsService{client: client}
+		zone, err := service.DescribeVpcDnsZoneById(ctx, id)
+		if err != nil {
+			return err
+		}
+		if zone == nil {
+			return fmt.Errorf("private zone %s not found while updating tags", id)
+		}
+		resourceName, err := buildVpcDnsZoneTagResourceName(zone, client.Region)
+		if err != nil {
+			return err
+		}
+		tagService := TagService{client: client}
 		if err := tagService.ModifyTags(ctx, resourceName, replaceTags, deleteTags); err != nil {
 			return err
 		}
@@ -429,6 +443,26 @@ func resourceTencentCloudVpcDnsZoneUpdate(d *schema.ResourceData, meta interface
 	}
 
 	return resourceTencentCloudVpcDnsZoneRead(d, meta)
+}
+
+func vpcDnsZoneTagResourceID(zone *vpcdns.PrivateZone) (string, error) {
+	if zone == nil || zone.DomainId == nil {
+		return "", fmt.Errorf("private zone has no DomainId for tags")
+	}
+
+	return strconv.FormatInt(*zone.DomainId, 10), nil
+}
+
+func buildVpcDnsZoneTagResourceName(zone *vpcdns.PrivateZone, region string) (string, error) {
+	resourceID, err := vpcDnsZoneTagResourceID(zone)
+	if err != nil {
+		return "", err
+	}
+	if zone.OwnerUin == nil {
+		return "", fmt.Errorf("private zone %s has no OwnerUin for tags", resourceID)
+	}
+
+	return fmt.Sprintf("qcs::%s:%s:uin/%d:%s/%s", VPCDNS_SERVICE_TYPE, region, *zone.OwnerUin, VPCDNS_RESOURCE_TYPE, resourceID), nil
 }
 
 func resourceTencentCloudVpcDnsZoneDelete(d *schema.ResourceData, meta interface{}) error {

--- a/tencentcloud/service_tencentcloud_vpcdns.go
+++ b/tencentcloud/service_tencentcloud_vpcdns.go
@@ -2,17 +2,46 @@ package tencentcloud
 
 import (
 	"context"
+	"log"
+
 	vpcdns "terraform-provider-tencentcloudenterprise/sdk/vpcdns/v20191025"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/connectivity"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/ratelimit"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/pkg/errors"
-	"log"
 )
 
 type VpcDnsService struct {
 	client *connectivity.TencentCloudClient
+}
+
+func (me *VpcDnsService) DescribeVpcDnsZoneById(ctx context.Context, zoneId string) (
+	zone *vpcdns.PrivateZone, errRet error) {
+	logId := getLogId(ctx)
+	request := vpcdns.NewDescribePrivateZoneRequest()
+	request.ZoneId = helper.String(zoneId)
+
+	var response *vpcdns.DescribePrivateZoneResponse
+	if err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
+		ratelimit.Check(request.GetAction())
+		result, err := me.client.UseVpcDnsClient().DescribePrivateZone(request)
+		if err != nil {
+			return retryError(err)
+		}
+		response = result
+		return nil
+	}); err != nil {
+		log.Printf("[CRITAL]%s read PrivateDns zone failed, reason: %v", logId, err)
+		return nil, err
+	}
+
+	if response == nil || response.Response == nil {
+		return nil, errors.New("DescribePrivateZone response is nil")
+	}
+
+	return response.Response.PrivateZone, nil
 }
 
 // CreateVpcDnsForwardRule create vpc dns forward rule


### PR DESCRIPTION
## Summary

- Correct VPCDNS zone tag reads and updates to use the registered private-zone resource identity
- Handle missing CIC system policy attachments as remote drift without crashing the provider