### PR TITLE
feat(tke): add Kubernetes user permissions resource

### DIFF
--- a/docs/resources/tencentcloudenterprise_tke_kubernetes_user_permissions.md
+++ b/docs/resources/tencentcloudenterprise_tke_kubernetes_user_permissions.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Tencent Kubernetes Engine(TKE)"
+layout: "tencentcloudenterprise"
+page_title: "TencentCloudEnterprise: tencentcloudenterprise_tke_kubernetes_user_permissions"
+sidebar_current: "docs-tencentcloudenterprise-resource-tke_kubernetes_user_permissions"
+description: |-
+  Provides a resource to manage TKE cluster user permissions via RBAC.
+---
+
+# tencentcloudenterprise_tke_kubernetes_user_permissions
+
+Provides a resource to manage TKE cluster user permissions via RBAC.
+
+## Example Usage
+
+```hcl
+resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "example" {
+  cluster_id = "cls-xxxxxxxx"
+  target_uin = "110000000000"
+
+  permissions {
+    role_name = "tke:admin"
+    role_type = "cluster"
+  }
+
+  permissions {
+    role_name = "tke:dev"
+    role_type = "namespace"
+    namespace = "default"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required, String, ForceNew) Cluster ID.
+* `target_uin` - (Required, String, ForceNew) Unique identifier of the user to be authorized (supports sub-account UIN and role UIN).
+* `permissions` - (Optional, Set) Complete list of permissions that the user should ultimately have. Uses declarative semantics, the passed list represents all permissions the user should ultimately have, the system will automatically calculate differences and perform necessary create/delete operations. When empty or not provided, all permissions for this user will be cleared.
+
+The `permissions` object supports the following:
+
+* `role_name` - (Required, String) Role name. Predefined roles include: tke:admin (cluster administrator), tke:ops (operations personnel), tke:dev (developer), tke:ro (read-only user), tke:ns:dev (namespace developer), tke:ns:ro (namespace read-only user), others are user-defined roles.
+* `role_type` - (Required, String) Authorization type. Enum values: cluster (cluster-level permissions, corresponding to ClusterRoleBinding), namespace (namespace-level permissions, corresponding to RoleBinding).
+* `is_custom` - (Optional, Bool) Whether it is a custom role, default false.
+* `namespace` - (Optional, String) Namespace. Required when role_type is namespace.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the resource.
+
+
+## Import
+
+tencentcloudenterprise_tke_kubernetes_user_permissions can be imported using the id, e.g.
+
+```
+terraform import tencentcloudenterprise_tke_kubernetes_user_permissions.example cls-xxxxxxxx:110000000000
+```
+

--- a/examples/tencentcloud-tke-kubernetes-user-permissions/README.md
+++ b/examples/tencentcloud-tke-kubernetes-user-permissions/README.md
@@ -1,0 +1,215 @@
+# TKE Kubernetes User Permissions Local Validation
+
+This example validates `tencentcloudenterprise_tke_kubernetes_user_permissions` with a provider binary built from the current source checkout. Terraform loads the binary through a development override, so no provider release is required.
+
+## Safety
+
+Use an existing test cluster and a dedicated test user. The resource treats `permissions` as the complete desired permission set for `target_uin`.
+
+- Applying an update can remove permissions omitted from the configuration.
+- Destroying the resource removes the managed cluster and namespace bindings.
+- Do not use a production account or an account with permissions that must be preserved.
+- Keep credentials, Terraform state, plans, and logs outside the repository.
+
+## Prerequisites
+
+- Go 1.23.x
+- Terraform CLI 1.5 or later
+- Credentials that can manage RBAC bindings in the target TKE cluster
+- The API domain and region of the target TCE environment
+
+## 1. Build the provider
+
+Run these commands from the repository root:
+
+```bash
+PROVIDER_BIN_DIR="${TMPDIR:-/tmp}/tencentcloudenterprise-provider-bin"
+mkdir -p "${PROVIDER_BIN_DIR}"
+go build -o "${PROVIDER_BIN_DIR}/terraform-provider-tencentcloudenterprise" .
+```
+
+Keep `PROVIDER_BIN_DIR` exported in the shell used for the remaining steps:
+
+```bash
+export PROVIDER_BIN_DIR
+```
+
+## 2. Create an isolated validation directory
+
+Run these commands from the repository root:
+
+```bash
+VALIDATION_DIR="${TMPDIR:-/tmp}/tke-kubernetes-user-permissions-validation"
+mkdir -p "${VALIDATION_DIR}"
+cp examples/tencentcloud-tke-kubernetes-user-permissions/* "${VALIDATION_DIR}/"
+cd "${VALIDATION_DIR}"
+```
+
+Create the active Terraform CLI configuration from the template:
+
+```bash
+sed "s|<PROVIDER_BIN_DIR>|${PROVIDER_BIN_DIR}|g" dev.tfrc.example > dev.tfrc
+export TF_CLI_CONFIG_FILE="${VALIDATION_DIR}/dev.tfrc"
+```
+
+The override value must be the directory containing the binary, not the binary path.
+
+## 3. Configure access
+
+Set credentials and endpoint information in environment variables:
+
+```bash
+export TENCENTCLOUD_SECRET_ID="<SECRET_ID>"
+export TENCENTCLOUD_SECRET_KEY="<SECRET_KEY>"
+export TENCENTCLOUD_REGION="<REGION>"
+export TENCENTCLOUD_DOMAIN="<API_DOMAIN>"
+export TENCENTCLOUD_PROTOCOL="HTTP"
+```
+
+Use `HTTPS` when required by the environment. `TENCENTCLOUD_DOMAIN` must contain only the API domain, without a URL path.
+
+Do not place credentials in `terraform.tfvars`, `dev.tfrc`, or tracked files.
+
+## 4. Configure the test resource
+
+Copy the variable template:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Replace the placeholder values with an existing test cluster ID and a dedicated test user UIN:
+
+```hcl
+cluster_id = "cls-xxxxxxxx"
+target_uin = "100000000000"
+
+permissions = [
+  {
+    role_name = "tke:ro"
+    role_type = "cluster"
+  }
+]
+```
+
+## 5. Initialize and confirm the local override
+
+```bash
+terraform init
+terraform validate
+```
+
+Terraform must print a warning that provider development overrides are in effect for:
+
+```text
+TencentCloud/tencentcloudenterprise
+```
+
+Stop if the warning is absent. Check `TF_CLI_CONFIG_FILE`, the absolute provider directory in `dev.tfrc`, and the binary name.
+
+## 6. Validate create and read
+
+```bash
+terraform plan -out=create.tfplan
+terraform apply create.tfplan
+terraform state show tencentcloudenterprise_tke_kubernetes_user_permissions.validation
+terraform output
+```
+
+Expected results:
+
+- The resource ID is `cluster_id:target_uin`.
+- The cluster-level `tke:ro` permission is present.
+- The target TKE cluster contains the corresponding ClusterRoleBinding.
+
+## 7. Validate update
+
+Add a namespace permission to `terraform.tfvars`:
+
+```hcl
+permissions = [
+  {
+    role_name = "tke:ro"
+    role_type = "cluster"
+  },
+  {
+    role_name = "tke:dev"
+    role_type = "namespace"
+    namespace = "default"
+  }
+]
+```
+
+Apply the update:
+
+```bash
+terraform plan -out=update.tfplan
+terraform apply update.tfplan
+terraform state show tencentcloudenterprise_tke_kubernetes_user_permissions.validation
+```
+
+Expected results:
+
+- Both permissions appear in state.
+- The cluster-level binding remains present.
+- A RoleBinding is present in the `default` namespace.
+
+## 8. Validate idempotency
+
+Without changing the configuration, run:
+
+```bash
+terraform plan
+```
+
+The expected result is `No changes`.
+
+## 9. Validate import
+
+Set the import values:
+
+```bash
+export TKE_CLUSTER_ID="<CLUSTER_ID>"
+export TKE_TARGET_UIN="<TARGET_UIN>"
+```
+
+Back up the local state, remove only the local state entry, and import the existing bindings:
+
+```bash
+terraform state pull > pre-import.tfstate
+terraform state rm tencentcloudenterprise_tke_kubernetes_user_permissions.validation
+terraform import \
+  tencentcloudenterprise_tke_kubernetes_user_permissions.validation \
+  "${TKE_CLUSTER_ID}:${TKE_TARGET_UIN}"
+terraform plan
+```
+
+`terraform state rm` does not delete remote RBAC bindings. The final plan should report no changes.
+
+## 10. Clean up
+
+Review the target user before cleanup. Destroy removes the permissions managed by this resource:
+
+```bash
+terraform plan -destroy -out=destroy.tfplan
+terraform apply destroy.tfplan
+```
+
+Confirm in the TKE cluster that the test user's ClusterRoleBinding and RoleBinding were removed.
+
+## Troubleshooting
+
+Enable Terraform logs only in the isolated validation directory:
+
+```bash
+export TF_LOG=DEBUG
+export TF_LOG_PATH="${VALIDATION_DIR}/terraform-debug.log"
+```
+
+Common checks:
+
+- Rebuild the binary after every source change.
+- Confirm `TF_CLI_CONFIG_FILE` points to the generated `dev.tfrc`.
+- Confirm the override directory contains `terraform-provider-tencentcloudenterprise`.
+- Confirm the endpoint protocol, domain, region, credentials, and TKE RBAC privileges.
+- Remove or securely archive state, plans, and debug logs when validation is complete.

--- a/examples/tencentcloud-tke-kubernetes-user-permissions/dev.tfrc.example
+++ b/examples/tencentcloud-tke-kubernetes-user-permissions/dev.tfrc.example
@@ -1,0 +1,7 @@
+provider_installation {
+  dev_overrides {
+    "TencentCloud/tencentcloudenterprise" = "<PROVIDER_BIN_DIR>"
+  }
+
+  direct {}
+}

--- a/examples/tencentcloud-tke-kubernetes-user-permissions/main.tf
+++ b/examples/tencentcloud-tke-kubernetes-user-permissions/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    tencentcloudenterprise = {
+      source = "TencentCloud/tencentcloudenterprise"
+    }
+  }
+}
+
+provider "tencentcloudenterprise" {}
+
+resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "validation" {
+  cluster_id = var.cluster_id
+  target_uin = var.target_uin
+
+  dynamic "permissions" {
+    for_each = var.permissions
+
+    content {
+      role_name = permissions.value.role_name
+      role_type = permissions.value.role_type
+      namespace = try(permissions.value.namespace, null)
+    }
+  }
+}
+
+output "resource_id" {
+  value = tencentcloudenterprise_tke_kubernetes_user_permissions.validation.id
+}
+
+output "permissions" {
+  value = tencentcloudenterprise_tke_kubernetes_user_permissions.validation.permissions
+}

--- a/examples/tencentcloud-tke-kubernetes-user-permissions/terraform.tfvars.example
+++ b/examples/tencentcloud-tke-kubernetes-user-permissions/terraform.tfvars.example
@@ -1,0 +1,9 @@
+cluster_id = "cls-xxxxxxxx"
+target_uin = "100000000000"
+
+permissions = [
+  {
+    role_name = "tke:ro"
+    role_type = "cluster"
+  }
+]

--- a/examples/tencentcloud-tke-kubernetes-user-permissions/variables.tf
+++ b/examples/tencentcloud-tke-kubernetes-user-permissions/variables.tf
@@ -1,0 +1,51 @@
+variable "cluster_id" {
+  description = "ID of the existing TKE cluster used for validation."
+  type        = string
+
+  validation {
+    condition     = startswith(var.cluster_id, "cls-")
+    error_message = "cluster_id must start with \"cls-\"."
+  }
+}
+
+variable "target_uin" {
+  description = "UIN of the dedicated test user whose TKE RBAC permissions will be managed."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.target_uin)) > 0
+    error_message = "target_uin must not be empty."
+  }
+}
+
+variable "permissions" {
+  description = "Complete desired permission set for the test user."
+  type = list(object({
+    role_name = string
+    role_type = string
+    namespace = optional(string)
+  }))
+
+  default = [
+    {
+      role_name = "tke:ro"
+      role_type = "cluster"
+    }
+  ]
+
+  validation {
+    condition = alltrue([
+      for permission in var.permissions :
+      contains(["cluster", "namespace"], permission.role_type)
+    ])
+    error_message = "Each role_type must be either \"cluster\" or \"namespace\"."
+  }
+
+  validation {
+    condition = alltrue([
+      for permission in var.permissions :
+      permission.role_type != "namespace" || try(length(trimspace(permission.namespace)) > 0, false)
+    ])
+    error_message = "namespace must be set when role_type is \"namespace\"."
+  }
+}

--- a/tencentcloud/provider.go
+++ b/tencentcloud/provider.go
@@ -274,6 +274,7 @@ Tencent Kubernetes Engine(TKE)
 	  Resource
 	    tencentcloudenterprise_tke_kubernetes_cluster
 	    tencentcloudenterprise_tke_kubernetes_scale_worker
+	    tencentcloudenterprise_tke_kubernetes_user_permissions
 	    tencentcloudenterprise_tke_kubernetes_cluster_attachment
 		tencentcloudenterprise_tke_kubernetes_cluster_endpoint
 		tencentcloudenterprise_tke_kubernetes_log_config
@@ -1322,6 +1323,7 @@ func Provider() *schema.Provider {
 			"tencentcloudenterprise_tke_kubernetes_encryption_protection": resourceTencentCloudKubernetesEncryptionProtection(),
 			"tencentcloudenterprise_tke_kubernetes_health_check_policy":   resourceTencentCloudKubernetesHealthCheckPolicy(),
 			"tencentcloudenterprise_tke_kubernetes_scale_worker":          resourceTencentCloudTkeScaleWorker(),
+			"tencentcloudenterprise_tke_kubernetes_user_permissions":      resourceTencentCloudTkeKubernetesUserPermissions(),
 			//"tencentcloudenterprise_tke_kubernetes_serverless_node_pool": resourceTkeServerLessNodePool(),
 			//"tencentcloudenterprise_tse_instance":                                   resourceTencentCloudTseInstance(),
 			"tencentcloudenterprise_tsf_cluster":                           resourceTencentCloudTsfCluster(),

--- a/tencentcloud/resource_tc_tke_kubernetes_user_permissions.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_user_permissions.go
@@ -1,0 +1,590 @@
+/*
+Provides a resource to manage TKE cluster user permissions via RBAC.
+
+# Example Usage
+
+```hcl
+
+	resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "example" {
+	  cluster_id = "cls-xxxxxxxx"
+	  target_uin = "110000000000"
+
+	  permissions {
+	    role_name = "tke:admin"
+	    role_type = "cluster"
+	  }
+
+	  permissions {
+	    role_name = "tke:dev"
+	    role_type = "namespace"
+	    namespace = "default"
+	  }
+	}
+
+```
+
+# Import
+
+terraform import tencentcloudenterprise_tke_kubernetes_user_permissions.example cls-xxxxxxxx:110000000000
+*/
+package tencentcloud
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// tkeRoleNameMap maps friendly role names from console to K8s ClusterRole names.
+var tkeRoleNameMap = map[string]string{
+	"admin":           "tke:admin",
+	"tke:admin":       "tke:admin",
+	"ops":             "tke:ops",
+	"tke:ops":         "tke:ops",
+	"ops team":        "tke:ops",
+	"developer":       "tke:dev",
+	"tke:dev":         "tke:dev",
+	"read-only":       "tke:ro",
+	"tke:ro":          "tke:ro",
+	"read-only users": "tke:ro",
+	"namespace dev":   "tke:ns:dev",
+	"tke:ns:dev":      "tke:ns:dev",
+	"namespace ro":    "tke:ns:ro",
+	"tke:ns:ro":       "tke:ns:ro",
+}
+
+// normalizeRoleName converts user input to the K8s ClusterRole name.
+func normalizeRoleName(input string) string {
+	lower := strings.ToLower(strings.TrimSpace(input))
+	if mapped, ok := tkeRoleNameMap[lower]; ok {
+		return mapped
+	}
+	return input
+}
+
+func init() {
+	registerResourceDescriptionProvider("tencentcloudenterprise_tke_kubernetes_user_permissions", CNDescription{
+		TerraformTypeCN: "TKE 集群用户权限",
+		DescriptionCN:   "用于管理 TKE 集群用户 RBAC 权限。通过声明式语义管理子账号在指定集群中的 ClusterRoleBinding 和 RoleBinding。",
+		AttributesCN: map[string]string{
+			"cluster_id":  "集群 ID。",
+			"target_uin":  "被授权的用户 UIN（支持子账号 UIN 和角色 UIN）。",
+			"permissions": "用户最终应拥有的完整权限列表。使用声明式语义，传入的列表代表用户最终应有的所有权限，系统会自动计算差异并执行增删操作。",
+			"role_name":   "角色名称。预置角色：tke:admin（集群管理员）、tke:ops（运维人员）、tke:dev（开发者）、tke:ro（只读用户）、tke:ns:dev（命名空间开发者）、tke:ns:ro（命名空间只读用户），其他为自定义角色。",
+			"role_type":   "授权类型。cluster：集群级权限（ClusterRoleBinding），namespace：命名空间级权限（RoleBinding）。",
+			"is_custom":   "是否为自定义角色，默认 false。",
+			"namespace":   "命名空间。role_type 为 namespace 时必填。",
+		},
+	})
+}
+
+func resourceTencentCloudTkeKubernetesUserPermissions() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a resource to manage TKE cluster user permissions via RBAC.",
+		Create:      resourceTencentCloudTkeKubernetesUserPermissionsCreate,
+		Read:        resourceTencentCloudTkeKubernetesUserPermissionsRead,
+		Update:      resourceTencentCloudTkeKubernetesUserPermissionsUpdate,
+		Delete:      resourceTencentCloudTkeKubernetesUserPermissionsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+			return validateTkeUserPermissions(d.Get("permissions"))
+		},
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Cluster ID.",
+			},
+			"target_uin": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique identifier of the user to be authorized (supports sub-account UIN and role UIN).",
+			},
+			"permissions": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Complete list of permissions that the user should ultimately have. Uses declarative semantics, the passed list represents all permissions the user should ultimately have, the system will automatically calculate differences and perform necessary create/delete operations. When empty or not provided, all permissions for this user will be cleared.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Role name. Predefined roles include: tke:admin (cluster administrator), tke:ops (operations personnel), tke:dev (developer), tke:ro (read-only user), tke:ns:dev (namespace developer), tke:ns:ro (namespace read-only user), others are user-defined roles.",
+						},
+						"role_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"cluster", "namespace"}, false),
+							Description:  "Authorization type. Enum values: cluster (cluster-level permissions, corresponding to ClusterRoleBinding), namespace (namespace-level permissions, corresponding to RoleBinding).",
+						},
+						"is_custom": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Whether it is a custom role, default false.",
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Namespace. Required when role_type is namespace.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func validateTkeUserPermissions(value interface{}) error {
+	permissions, ok := value.(*schema.Set)
+	if !ok {
+		return nil
+	}
+
+	for i, item := range permissions.List() {
+		permission, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("permissions[%d] has an invalid value", i)
+		}
+
+		roleType, _ := permission["role_type"].(string)
+		roleType = strings.TrimSpace(roleType)
+		namespace := ""
+		if value, ok := permission["namespace"].(string); ok {
+			namespace = strings.TrimSpace(value)
+		}
+
+		switch roleType {
+		case "namespace":
+			if namespace == "" {
+				return fmt.Errorf("permissions[%d].namespace must be set when role_type is \"namespace\"", i)
+			}
+		case "cluster":
+			if namespace != "" {
+				return fmt.Errorf("permissions[%d].namespace must not be set when role_type is \"cluster\"", i)
+			}
+		default:
+			return fmt.Errorf("permissions[%d].role_type must be either \"cluster\" or \"namespace\"", i)
+		}
+	}
+
+	return nil
+}
+
+// buildClusterRoleBindingYAML builds a ClusterRoleBinding YAML for apply.
+func buildClusterRoleBindingYAML(uin, nickname, subjectName, roleName string) string {
+	tmpl := `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"%s-ClusterRole","labels":{"cloud.tencent.com/tke-account":"%s"},"annotations":{"cloud.tencent.com/tke-account-nickname":"%s"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"%s"},"subjects":[{"kind":"User","name":"%s"}]}`
+	return fmt.Sprintf(tmpl, uin, uin, nickname, roleName, subjectName)
+}
+
+// buildRoleBindingYAML builds a RoleBinding YAML for apply.
+func buildRoleBindingYAML(uin, nickname, subjectName, roleName, namespace string) string {
+	tmpl := `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"name":"%s-Role-%s","namespace":"%s","labels":{"cloud.tencent.com/tke-account":"%s"},"annotations":{"cloud.tencent.com/tke-account-nickname":"%s"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"%s"},"subjects":[{"kind":"User","name":"%s"}]}`
+	return fmt.Sprintf(tmpl, uin, namespace, namespace, uin, nickname, roleName, subjectName)
+}
+
+// resolveTkeAccountNickname resolves a sub-account UIN for console display.
+// Role UINs and lookup failures fall back to the UIN to preserve compatibility.
+func resolveTkeAccountNickname(ctx context.Context, client *TencentCloudClient, targetUin string) string {
+	uin, err := strconv.ParseInt(targetUin, 10, 64)
+	if err != nil {
+		return targetUin
+	}
+
+	service := CamService{client: client.apiV3Conn}
+	userName, err := service.DescribeUserNameByUin(ctx, uin)
+	if err != nil {
+		log.Printf("[WARN] resolve CAM user name for UIN %s failed: %v", targetUin, err)
+		return targetUin
+	}
+	if userName == "" {
+		return targetUin
+	}
+
+	return userName
+}
+
+func resolveTkeSubjectName(ctx context.Context, client *TencentCloudClient, clusterId, targetUin string) (string, error) {
+	service := TkeService{client: client.apiV3Conn}
+	commonName, err := service.DescribeClusterCommonName(ctx, clusterId, targetUin)
+	if err != nil {
+		return "", err
+	}
+	if commonName == "" {
+		return "", fmt.Errorf("no cluster certificate common name found for account %s in cluster %s", targetUin, clusterId)
+	}
+	return commonName, nil
+}
+
+// buildApplyPath returns the apply endpoint path for a given cluster.
+func buildApplyPath(clusterId string) string {
+	return fmt.Sprintf("/apis/platform.tke/v1/clusters/%s/apply", clusterId)
+}
+
+// applyBinding calls the TCE apply endpoint to create/update a K8s RBAC binding.
+func applyBinding(me *TkeService, ctx context.Context, clusterId, yamlBody string) error {
+	encodedBody := base64.StdEncoding.EncodeToString([]byte(yamlBody))
+	path := buildApplyPath(clusterId)
+	encoded := true
+	_, err := me.ForwardPlatformRequestV3WithOptions(ctx, "POST", path, clusterId, encodedBody, "", "", &encoded)
+	return err
+}
+
+// deleteBinding deletes a K8s RBAC binding.
+func deleteBinding(me *TkeService, ctx context.Context, clusterId, path string) error {
+	_, err := me.ForwardPlatformRequestV3(ctx, "DELETE", path, clusterId, "")
+	return err
+}
+
+// parseBindingList parses a K8s binding list JSON response and returns binding names and their roleRef.
+func parseBindingList(responseBody string) ([]map[string]string, error) {
+	var result struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			RoleRef struct {
+				Name string `json:"name"`
+			} `json:"roleRef"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(responseBody), &result); err != nil {
+		return nil, err
+	}
+	var bindings []map[string]string
+	for _, item := range result.Items {
+		bindings = append(bindings, map[string]string{
+			"name":     item.Metadata.Name,
+			"roleName": item.RoleRef.Name,
+		})
+	}
+	return bindings, nil
+}
+
+// bindingKey generates a unique key for a permission for diff comparison.
+func bindingKey(perm map[string]interface{}) string {
+	roleName := normalizeRoleName(perm["role_name"].(string))
+	roleType := perm["role_type"].(string)
+	namespace := ""
+	if v, ok := perm["namespace"].(string); ok {
+		namespace = v
+	}
+	if roleType == "namespace" {
+		return fmt.Sprintf("%s|%s|%s", roleName, roleType, namespace)
+	}
+	return fmt.Sprintf("%s|%s", roleName, roleType)
+}
+
+func resourceTencentCloudTkeKubernetesUserPermissionsCreate(d *schema.ResourceData, meta interface{}) error {
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_user_permissions.create")()
+	defer inconsistentCheck(d, meta)()
+
+	logId := getLogId(contextNil)
+	ctx := context.WithValue(context.Background(), logIdKey, logId)
+
+	service := TkeService{client: meta.(*TencentCloudClient).apiV3Conn}
+
+	var clusterId, targetUin string
+	if v, ok := d.GetOk("cluster_id"); ok {
+		clusterId = v.(string)
+	}
+	if v, ok := d.GetOk("target_uin"); ok {
+		targetUin = v.(string)
+	}
+	if err := validateTkeUserPermissions(d.Get("permissions")); err != nil {
+		return err
+	}
+
+	if v, ok := d.GetOk("permissions"); ok {
+		permissions := v.(*schema.Set).List()
+		if len(permissions) == 0 {
+			d.SetId(fmt.Sprintf("%s:%s", clusterId, targetUin))
+			return resourceTencentCloudTkeKubernetesUserPermissionsRead(d, meta)
+		}
+
+		nickname := resolveTkeAccountNickname(ctx, meta.(*TencentCloudClient), targetUin)
+		subjectName, err := resolveTkeSubjectName(ctx, meta.(*TencentCloudClient), clusterId, targetUin)
+		if err != nil {
+			return err
+		}
+
+		for _, item := range permissions {
+			permMap := item.(map[string]interface{})
+			roleName := normalizeRoleName(permMap["role_name"].(string))
+			roleType := permMap["role_type"].(string)
+			namespace := ""
+			if v, ok := permMap["namespace"].(string); ok {
+				namespace = v
+			}
+
+			var yamlBody string
+			if roleType == "namespace" {
+				yamlBody = buildRoleBindingYAML(targetUin, nickname, subjectName, roleName, namespace)
+			} else {
+				yamlBody = buildClusterRoleBindingYAML(targetUin, nickname, subjectName, roleName)
+			}
+
+			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+				if e := applyBinding(&service, ctx, clusterId, yamlBody); e != nil {
+					return retryError(e)
+				}
+				return nil
+			})
+			if err != nil {
+				log.Printf("[CRITAL]%s create kubernetes user permission failed, clusterId: %s, role: %s, reason:%+v",
+					logId, clusterId, roleName, err)
+				return err
+			}
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", clusterId, targetUin))
+	return resourceTencentCloudTkeKubernetesUserPermissionsRead(d, meta)
+}
+
+func resourceTencentCloudTkeKubernetesUserPermissionsRead(d *schema.ResourceData, meta interface{}) error {
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_user_permissions.read")()
+	defer inconsistentCheck(d, meta)()
+
+	logId := getLogId(contextNil)
+	ctx := context.WithValue(context.Background(), logIdKey, logId)
+
+	service := TkeService{client: meta.(*TencentCloudClient).apiV3Conn}
+
+	idParts := strings.SplitN(d.Id(), ":", 2)
+	if len(idParts) != 2 {
+		return fmt.Errorf("invalid ID format, expected cluster_id:target_uin, got: %s", d.Id())
+	}
+	clusterId := idParts[0]
+	targetUin := idParts[1]
+
+	_ = d.Set("cluster_id", clusterId)
+	_ = d.Set("target_uin", targetUin)
+
+	bindings, err := readUserPermissionsByCluster(&service, ctx, targetUin, clusterId)
+	if err != nil {
+		log.Printf("[WARN]%s read permissions for cluster %s failed: %v", logId, clusterId, err)
+	}
+
+	if len(bindings) == 0 {
+		log.Printf("[WARN]%s resource `tencentcloudenterprise_tke_kubernetes_user_permissions` [%s] has no permissions, please check if it has been deleted.\n", logId, d.Id())
+	}
+
+	_ = d.Set("permissions", bindings)
+	return nil
+}
+
+func readUserPermissionsByCluster(service *TkeService, ctx context.Context, uin, clusterId string) ([]map[string]interface{}, error) {
+	var permissions []map[string]interface{}
+
+	// Read ClusterRoleBindings
+	crbBody, err := service.DescribeClusterRoleBindingsByUin(ctx, clusterId, uin)
+	if err == nil && crbBody != "" {
+		bindings, parseErr := parseBindingList(crbBody)
+		if parseErr == nil {
+			for _, b := range bindings {
+				permissions = append(permissions, map[string]interface{}{
+					"role_name": b["roleName"],
+					"role_type": "cluster",
+					"is_custom": !isPredefinedRole(b["roleName"]),
+				})
+			}
+		}
+	}
+
+	// Read RoleBindings (namespace level)
+	rbBody, err := service.DescribeRoleBindingsByUin(ctx, clusterId, uin)
+	if err == nil && rbBody != "" {
+		bindings, parseErr := parseBindingList(rbBody)
+		if parseErr == nil {
+			for _, b := range bindings {
+				// Extract namespace from binding name pattern: {uin}-Role-{namespace}
+				namespace := extractNamespaceFromBindingName(b["name"], uin)
+				permissions = append(permissions, map[string]interface{}{
+					"role_name": b["roleName"],
+					"role_type": "namespace",
+					"namespace": namespace,
+					"is_custom": !isPredefinedRole(b["roleName"]),
+				})
+			}
+		}
+	}
+
+	return permissions, nil
+}
+
+func isPredefinedRole(roleName string) bool {
+	predefined := map[string]bool{
+		"tke:admin":  true,
+		"tke:ops":    true,
+		"tke:dev":    true,
+		"tke:ro":     true,
+		"tke:ns:dev": true,
+		"tke:ns:ro":  true,
+	}
+	return predefined[roleName]
+}
+
+func extractNamespaceFromBindingName(name, uin string) string {
+	prefix := fmt.Sprintf("%s-Role-", uin)
+	if strings.HasPrefix(name, prefix) {
+		return strings.TrimPrefix(name, prefix)
+	}
+	return ""
+}
+
+func resourceTencentCloudTkeKubernetesUserPermissionsUpdate(d *schema.ResourceData, meta interface{}) error {
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_user_permissions.update")()
+	defer inconsistentCheck(d, meta)()
+
+	logId := getLogId(contextNil)
+	ctx := context.WithValue(context.Background(), logIdKey, logId)
+
+	service := TkeService{client: meta.(*TencentCloudClient).apiV3Conn}
+
+	idParts := strings.SplitN(d.Id(), ":", 2)
+	if len(idParts) != 2 {
+		return fmt.Errorf("invalid ID format, expected cluster_id:target_uin, got: %s", d.Id())
+	}
+	clusterId := idParts[0]
+	targetUin := idParts[1]
+
+	if d.HasChange("permissions") {
+		oldInterface, newInterface := d.GetChange("permissions")
+		if err := validateTkeUserPermissions(newInterface); err != nil {
+			return err
+		}
+		olds := oldInterface.(*schema.Set)
+		news := newInterface.(*schema.Set)
+		remove := olds.Difference(news).List()
+		add := news.Difference(olds).List()
+		nickname := ""
+		subjectName := ""
+		if len(add) > 0 {
+			nickname = resolveTkeAccountNickname(ctx, meta.(*TencentCloudClient), targetUin)
+			resolvedSubjectName, resolveErr := resolveTkeSubjectName(ctx, meta.(*TencentCloudClient), clusterId, targetUin)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			subjectName = resolvedSubjectName
+		}
+
+		// Remove old permissions
+		for _, item := range remove {
+			permMap := item.(map[string]interface{})
+			roleType := permMap["role_type"].(string)
+			namespace := ""
+			if v, ok := permMap["namespace"].(string); ok {
+				namespace = v
+			}
+
+			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+				var deleteErr error
+				if roleType == "namespace" {
+					bindingName := fmt.Sprintf("%s-Role-%s", targetUin, namespace)
+					path := fmt.Sprintf("/apis/rbac.authorization.k8s.io/v1/namespaces/%s/rolebindings/%s", namespace, bindingName)
+					deleteErr = deleteBinding(&service, ctx, clusterId, path)
+				} else {
+					bindingName := fmt.Sprintf("%s-ClusterRole", targetUin)
+					path := fmt.Sprintf("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/%s", bindingName)
+					deleteErr = deleteBinding(&service, ctx, clusterId, path)
+				}
+				if deleteErr != nil {
+					log.Printf("[WARN]%s delete binding failed (may already not exist), err: %v", logId, deleteErr)
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		// Add new permissions
+		for _, item := range add {
+			permMap := item.(map[string]interface{})
+			roleName := normalizeRoleName(permMap["role_name"].(string))
+			roleType := permMap["role_type"].(string)
+			namespace := ""
+			if v, ok := permMap["namespace"].(string); ok {
+				namespace = v
+			}
+
+			var yamlBody string
+			if roleType == "namespace" {
+				yamlBody = buildRoleBindingYAML(targetUin, nickname, subjectName, roleName, namespace)
+			} else {
+				yamlBody = buildClusterRoleBindingYAML(targetUin, nickname, subjectName, roleName)
+			}
+
+			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+				if e := applyBinding(&service, ctx, clusterId, yamlBody); e != nil {
+					return retryError(e)
+				}
+				return nil
+			})
+			if err != nil {
+				log.Printf("[CRITAL]%s create kubernetes user permission failed, clusterId: %s, role: %s, reason:%+v",
+					logId, clusterId, roleName, err)
+				return err
+			}
+		}
+	}
+
+	return resourceTencentCloudTkeKubernetesUserPermissionsRead(d, meta)
+}
+
+func resourceTencentCloudTkeKubernetesUserPermissionsDelete(d *schema.ResourceData, meta interface{}) error {
+	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_user_permissions.delete")()
+	defer inconsistentCheck(d, meta)()
+
+	logId := getLogId(contextNil)
+	ctx := context.WithValue(context.Background(), logIdKey, logId)
+
+	service := TkeService{client: meta.(*TencentCloudClient).apiV3Conn}
+
+	idParts := strings.SplitN(d.Id(), ":", 2)
+	if len(idParts) != 2 {
+		return fmt.Errorf("invalid ID format, expected cluster_id:target_uin, got: %s", d.Id())
+	}
+	clusterId := idParts[0]
+	targetUin := idParts[1]
+
+	// Delete ClusterRoleBinding
+	crbName := fmt.Sprintf("%s-ClusterRole", targetUin)
+	crbPath := fmt.Sprintf("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/%s", crbName)
+	if err := deleteBinding(&service, ctx, clusterId, crbPath); err != nil {
+		log.Printf("[WARN]%s delete ClusterRoleBinding %s in cluster %s failed: %v", logId, crbName, clusterId, err)
+	}
+
+	// Delete all RoleBindings for this uin
+	rbBody, err := service.DescribeRoleBindingsByUin(ctx, clusterId, targetUin)
+	if err == nil && rbBody != "" {
+		bindings, parseErr := parseBindingList(rbBody)
+		if parseErr == nil {
+			for _, b := range bindings {
+				ns := extractNamespaceFromBindingName(b["name"], targetUin)
+				if ns == "" {
+					continue
+				}
+				rbPath := fmt.Sprintf("/apis/rbac.authorization.k8s.io/v1/namespaces/%s/rolebindings/%s", ns, b["name"])
+				if err := deleteBinding(&service, ctx, clusterId, rbPath); err != nil {
+					log.Printf("[WARN]%s delete RoleBinding %s in cluster %s ns %s failed: %v", logId, b["name"], clusterId, ns, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/tencentcloud/resource_tc_tke_kubernetes_user_permissions_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_user_permissions_test.go
@@ -1,0 +1,394 @@
+package tencentcloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestBuildTkeClusterRoleBindingYAML(t *testing.T) {
+	body := buildClusterRoleBindingYAML("100000000001", "test-user", "1234567890", "tke:ro")
+
+	var binding struct {
+		Metadata struct {
+			Annotations map[string]string `json:"annotations"`
+		} `json:"metadata"`
+		RoleRef struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		} `json:"roleRef"`
+		Subjects []struct {
+			Name string `json:"name"`
+		} `json:"subjects"`
+	}
+	if err := json.Unmarshal([]byte(body), &binding); err != nil {
+		t.Fatalf("unmarshal ClusterRoleBinding: %v", err)
+	}
+	if got := binding.Metadata.Annotations["cloud.tencent.com/tke-account-nickname"]; got != "test-user" {
+		t.Fatalf("unexpected account nickname: %q", got)
+	}
+	if binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != "tke:ro" {
+		t.Fatalf("unexpected roleRef: kind=%q name=%q", binding.RoleRef.Kind, binding.RoleRef.Name)
+	}
+	if len(binding.Subjects) != 1 || binding.Subjects[0].Name != "1234567890" {
+		t.Fatalf("unexpected subject: %+v", binding.Subjects)
+	}
+}
+
+func TestBuildTkeRoleBindingYAML(t *testing.T) {
+	body := buildRoleBindingYAML("100000000001", "test-user", "1234567890", "tke:dev", "kube-system")
+
+	var binding struct {
+		Metadata struct {
+			Name        string            `json:"name"`
+			Namespace   string            `json:"namespace"`
+			Annotations map[string]string `json:"annotations"`
+		} `json:"metadata"`
+		RoleRef struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		} `json:"roleRef"`
+		Subjects []struct {
+			Name string `json:"name"`
+		} `json:"subjects"`
+	}
+	if err := json.Unmarshal([]byte(body), &binding); err != nil {
+		t.Fatalf("unmarshal RoleBinding: %v", err)
+	}
+	if binding.Metadata.Name != "100000000001-Role-kube-system" {
+		t.Fatalf("unexpected binding name: %q", binding.Metadata.Name)
+	}
+	if binding.Metadata.Namespace != "kube-system" {
+		t.Fatalf("unexpected namespace: %q", binding.Metadata.Namespace)
+	}
+	if got := binding.Metadata.Annotations["cloud.tencent.com/tke-account-nickname"]; got != "test-user" {
+		t.Fatalf("unexpected account nickname: %q", got)
+	}
+	if binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != "tke:dev" {
+		t.Fatalf("unexpected roleRef: kind=%q name=%q", binding.RoleRef.Kind, binding.RoleRef.Name)
+	}
+	if len(binding.Subjects) != 1 || binding.Subjects[0].Name != "1234567890" {
+		t.Fatalf("unexpected subject: %+v", binding.Subjects)
+	}
+}
+
+func TestValidateTkeUserPermissions(t *testing.T) {
+	permissionResource := resourceTencentCloudTkeKubernetesUserPermissions().Schema["permissions"].Elem.(*schema.Resource)
+	hash := schema.HashResource(permissionResource)
+
+	tests := []struct {
+		name       string
+		permission map[string]interface{}
+		wantError  string
+	}{
+		{
+			name: "valid cluster permission",
+			permission: map[string]interface{}{
+				"role_name": "tke:ro",
+				"role_type": "cluster",
+			},
+		},
+		{
+			name: "valid namespace permission",
+			permission: map[string]interface{}{
+				"role_name": "tke:dev",
+				"role_type": "namespace",
+				"namespace": "default",
+			},
+		},
+		{
+			name: "missing namespace",
+			permission: map[string]interface{}{
+				"role_name": "tke:dev",
+				"role_type": "namespace",
+			},
+			wantError: `namespace must be set when role_type is "namespace"`,
+		},
+		{
+			name: "blank namespace",
+			permission: map[string]interface{}{
+				"role_name": "tke:dev",
+				"role_type": "namespace",
+				"namespace": "   ",
+			},
+			wantError: `namespace must be set when role_type is "namespace"`,
+		},
+		{
+			name: "cluster permission with namespace",
+			permission: map[string]interface{}{
+				"role_name": "tke:ro",
+				"role_type": "cluster",
+				"namespace": "default",
+			},
+			wantError: `namespace must not be set when role_type is "cluster"`,
+		},
+		{
+			name: "invalid role type",
+			permission: map[string]interface{}{
+				"role_name": "tke:ro",
+				"role_type": "project",
+			},
+			wantError: `role_type must be either "cluster" or "namespace"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			permissions := schema.NewSet(hash, []interface{}{test.permission})
+			err := validateTkeUserPermissions(permissions)
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("unexpected validation error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validation error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestAccTencentCloudTkeKubernetesUserPermissions_basic(t *testing.T) {
+	t.Parallel()
+
+	clusterId := os.Getenv("TF_ACC_TKE_CLUSTER_ID")
+	targetUin := os.Getenv("TF_ACC_TKE_TARGET_UIN")
+	if clusterId == "" || targetUin == "" {
+		t.Skip("set TF_ACC_TKE_CLUSTER_ID and TF_ACC_TKE_TARGET_UIN to run TKE user permissions acceptance test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTkeKubernetesUserPermissionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTkeKubernetesUserPermissionsEmpty(clusterId, targetUin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTkeKubernetesUserPermissionsExists("tencentcloudenterprise_tke_kubernetes_user_permissions.test"),
+					resource.TestCheckResourceAttr("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "permissions.#", "0"),
+				),
+			},
+			{
+				Config: testAccTkeKubernetesUserPermissionsBasic(clusterId, targetUin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTkeKubernetesUserPermissionsExists("tencentcloudenterprise_tke_kubernetes_user_permissions.test"),
+					resource.TestCheckResourceAttrSet("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "target_uin"),
+					resource.TestCheckResourceAttr("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "permissions.#", "1"),
+					testAccCheckTkeBindingAPI("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "cluster", "", "tke:ro"),
+				),
+			},
+			{
+				Config: testAccTkeKubernetesUserPermissionsUpdate(clusterId, targetUin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTkeKubernetesUserPermissionsExists("tencentcloudenterprise_tke_kubernetes_user_permissions.test"),
+					resource.TestCheckResourceAttr("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "permissions.#", "2"),
+					testAccCheckTkeBindingAPI("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "namespace", "default", "tke:dev"),
+				),
+			},
+			{
+				Config: testAccTkeKubernetesUserPermissionsNamespaceUpdate(clusterId, targetUin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTkeKubernetesUserPermissionsExists("tencentcloudenterprise_tke_kubernetes_user_permissions.test"),
+					resource.TestCheckTypeSetElemNestedAttrs("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "permissions.*", map[string]string{
+						"role_name": "tke:dev",
+						"role_type": "namespace",
+						"namespace": "kube-system",
+					}),
+					testAccCheckTkeBindingAPI("tencentcloudenterprise_tke_kubernetes_user_permissions.test", "namespace", "kube-system", "tke:dev"),
+				),
+			},
+			{
+				ResourceName:      "tencentcloudenterprise_tke_kubernetes_user_permissions.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s:%s", clusterId, targetUin),
+			},
+		},
+	})
+}
+
+func testAccTkeKubernetesUserPermissionsEmpty(clusterId, targetUin string) string {
+	return fmt.Sprintf(`
+resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "test" {
+  cluster_id = "%s"
+  target_uin = "%s"
+}
+`, clusterId, targetUin)
+}
+
+func testAccCheckTkeBindingAPI(resourceName, roleType, namespace, roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+		idParts := strings.SplitN(rs.Primary.ID, ":", 2)
+		if len(idParts) != 2 {
+			return fmt.Errorf("invalid resource ID: %s", rs.Primary.ID)
+		}
+		clusterId, targetUin := idParts[0], idParts[1]
+
+		uin, err := strconv.ParseInt(targetUin, 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse target UIN: %w", err)
+		}
+
+		client := testAccProvider.Meta().(*TencentCloudClient).apiV3Conn
+		camService := CamService{client: client}
+		expectedNickname, err := camService.DescribeUserNameByUin(context.Background(), uin)
+		if err != nil {
+			return fmt.Errorf("query CAM user name: %w", err)
+		}
+		if expectedNickname == "" || expectedNickname == targetUin {
+			return fmt.Errorf("CAM did not resolve a user name for UIN %s", targetUin)
+		}
+
+		tkeService := TkeService{client: client}
+		expectedSubjectName, err := tkeService.DescribeClusterCommonName(context.Background(), clusterId, targetUin)
+		if err != nil {
+			return fmt.Errorf("query TKE cluster common name: %w", err)
+		}
+		if expectedSubjectName == "" || expectedSubjectName == targetUin {
+			return fmt.Errorf("TKE did not resolve a cluster common name for UIN %s", targetUin)
+		}
+
+		var responseBody, bindingName string
+		if roleType == "namespace" {
+			responseBody, err = tkeService.DescribeRoleBindingsByUin(context.Background(), clusterId, targetUin)
+			bindingName = fmt.Sprintf("%s-Role-%s", targetUin, namespace)
+		} else {
+			responseBody, err = tkeService.DescribeClusterRoleBindingsByUin(context.Background(), clusterId, targetUin)
+			bindingName = fmt.Sprintf("%s-ClusterRole", targetUin)
+		}
+		if err != nil {
+			return fmt.Errorf("query TKE bindings: %w", err)
+		}
+
+		var list struct {
+			Items []struct {
+				Metadata struct {
+					Name        string            `json:"name"`
+					Namespace   string            `json:"namespace"`
+					Annotations map[string]string `json:"annotations"`
+				} `json:"metadata"`
+				RoleRef struct {
+					Kind string `json:"kind"`
+					Name string `json:"name"`
+				} `json:"roleRef"`
+				Subjects []struct {
+					Name string `json:"name"`
+				} `json:"subjects"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(responseBody), &list); err != nil {
+			return fmt.Errorf("parse TKE binding response: %w", err)
+		}
+		for _, binding := range list.Items {
+			if binding.Metadata.Name != bindingName {
+				continue
+			}
+			if got := binding.Metadata.Annotations["cloud.tencent.com/tke-account-nickname"]; got != expectedNickname {
+				return fmt.Errorf("binding nickname mismatch: got %q, want %q", got, expectedNickname)
+			}
+			if binding.Metadata.Namespace != namespace {
+				return fmt.Errorf("binding namespace mismatch: got %q, want %q", binding.Metadata.Namespace, namespace)
+			}
+			if binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != roleName {
+				return fmt.Errorf("binding roleRef mismatch: kind=%q name=%q", binding.RoleRef.Kind, binding.RoleRef.Name)
+			}
+			if len(binding.Subjects) != 1 || binding.Subjects[0].Name != expectedSubjectName {
+				return fmt.Errorf("binding subject mismatch: got %+v, want %q", binding.Subjects, expectedSubjectName)
+			}
+			return nil
+		}
+
+		return fmt.Errorf("binding %s not found", bindingName)
+	}
+}
+
+func testAccCheckTkeKubernetesUserPermissionsExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is not set")
+		}
+		return nil
+	}
+}
+
+func testAccCheckTkeKubernetesUserPermissionsDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tencentcloudenterprise_tke_kubernetes_user_permissions" {
+			continue
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccTkeKubernetesUserPermissionsBasic(clusterId, targetUin string) string {
+	return fmt.Sprintf(`
+resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "test" {
+  cluster_id = "%s"
+  target_uin = "%s"
+
+  permissions {
+    role_name = "tke:ro"
+    role_type = "cluster"
+  }
+}
+`, clusterId, targetUin)
+}
+
+func testAccTkeKubernetesUserPermissionsUpdate(clusterId, targetUin string) string {
+	return fmt.Sprintf(`
+resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "test" {
+  cluster_id = "%s"
+  target_uin = "%s"
+
+  permissions {
+    role_name = "tke:ro"
+    role_type = "cluster"
+  }
+
+  permissions {
+    role_name = "tke:dev"
+    role_type = "namespace"
+    namespace = "default"
+  }
+}
+`, clusterId, targetUin)
+}
+
+func testAccTkeKubernetesUserPermissionsNamespaceUpdate(clusterId, targetUin string) string {
+	return fmt.Sprintf(`
+resource "tencentcloudenterprise_tke_kubernetes_user_permissions" "test" {
+  cluster_id = "%s"
+  target_uin = "%s"
+
+  permissions {
+    role_name = "tke:ro"
+    role_type = "cluster"
+  }
+
+  permissions {
+    role_name = "tke:dev"
+    role_type = "namespace"
+    namespace = "kube-system"
+  }
+}
+`, clusterId, targetUin)
+}

--- a/tencentcloud/service_tencentcloud_cam.go
+++ b/tencentcloud/service_tencentcloud_cam.go
@@ -769,6 +769,33 @@ func (me *CamService) DescribeCamServiceLinkedRole(ctx context.Context, roleId s
 
 // User related methods
 
+func (me *CamService) DescribeUserNameByUin(ctx context.Context, uin int64) (userName string, errRet error) {
+	logId := getLogId(ctx)
+	request := cam.NewGetUserListByUinListRequest()
+	request.UinList = []*int64{&uin}
+
+	ratelimit.Check(request.GetAction())
+	response, err := me.client.UseCamClient().GetUserListByUinList(request)
+	if err != nil {
+		log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+			logId, request.GetAction(), request.ToJsonString(), err.Error())
+		return "", err
+	}
+	log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+		logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+	if response == nil || response.Response == nil {
+		return "", nil
+	}
+	for _, user := range response.Response.UserList {
+		if user.UserUin != nil && *user.UserUin == uint64(uin) && user.UserName != nil {
+			return *user.UserName, nil
+		}
+	}
+
+	return "", nil
+}
+
 func (me *CamService) DescribeUserById(ctx context.Context, userId string) (user *cam.SubAccountFilter, errRet error) {
 	logId := getLogId(ctx)
 	request := cam.NewListSubAccountsRequest()

--- a/tencentcloud/service_tencentcloud_tke.go
+++ b/tencentcloud/service_tencentcloud_tke.go
@@ -2798,3 +2798,55 @@ func (me *TkeService) DescribeKubernetesChartsByFilter(ctx context.Context, para
 	ret = response.Response.AppCharts
 	return
 }
+
+// DescribeClusterRoleBindingsByUin lists ClusterRoleBindings for a given uin in a cluster.
+func (me *TkeService) DescribeClusterRoleBindingsByUin(ctx context.Context, clusterId, uin string) (responseBody string, errRet error) {
+	path := fmt.Sprintf("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?labelSelector=cloud.tencent.com/tke-account=%s", uin)
+	return me.ForwardPlatformRequestV3(ctx, "GET", path, clusterId, "")
+}
+
+// DescribeRoleBindingsByUin lists RoleBindings for a given uin across all namespaces.
+func (me *TkeService) DescribeRoleBindingsByUin(ctx context.Context, clusterId, uin string) (responseBody string, errRet error) {
+	path := fmt.Sprintf("/apis/rbac.authorization.k8s.io/v1/rolebindings?labelSelector=cloud.tencent.com/tke-account=%s", uin)
+	return me.ForwardPlatformRequestV3(ctx, "GET", path, clusterId, "")
+}
+
+// DescribeClusterCommonName resolves an account identifier to the CN used by its cluster client certificate.
+func (me *TkeService) DescribeClusterCommonName(ctx context.Context, clusterId, accountId string) (commonName string, errRet error) {
+	logId := getLogId(ctx)
+	resolve := func(isRole bool) (string, error) {
+		request := tke.NewDescribeClusterCommonNamesRequest()
+		request.ClusterId = helper.String(clusterId)
+		if isRole {
+			request.RoleIds = []*string{helper.String(accountId)}
+		} else {
+			request.SubaccountUins = []*string{helper.String(accountId)}
+		}
+
+		ratelimit.Check(request.GetAction())
+		response, err := me.client.UseTkeClient().DescribeClusterCommonNames(request)
+		if err != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, request body [%s], reason[%s]\n",
+				logId, request.GetAction(), request.ToJsonString(), err.Error())
+			return "", err
+		}
+		log.Printf("[DEBUG]%s api[%s] success, request body [%s], response body [%s]\n",
+			logId, request.GetAction(), request.ToJsonString(), response.ToJsonString())
+
+		if response == nil || response.Response == nil {
+			return "", nil
+		}
+		for _, item := range response.Response.CommonNames {
+			if item.CN != nil && *item.CN != "" {
+				return *item.CN, nil
+			}
+		}
+		return "", nil
+	}
+
+	commonName, err := resolve(false)
+	if err != nil || commonName != "" {
+		return commonName, err
+	}
+	return resolve(true)
+}


### PR DESCRIPTION
## Summary
- add `tencentcloudenterprise_tke_kubernetes_user_permissions` for declarative TKE RBAC management
- support cluster-level and namespace-level permissions, updates, and imports
- include acceptance coverage, generated documentation, and source-build local validation fixtures