### PR TITLE
fix(ccn): clear route table policies on destroy

### DIFF
--- a/sdk/ccn/v20170312/models.go
+++ b/sdk/ccn/v20170312/models.go
@@ -2705,7 +2705,7 @@ type ReplaceCcnRouteTableAggregatePolicysRequest struct {
 	RouteTableId *string `json:"RouteTableId,omitempty" name:"RouteTableId"`
 	// 新的路由接收策略。
 
-	Policys []*CcnRouteTableAggregatePolicy `json:"Policys,omitempty" name:"Policys"`
+	Policys []*CcnRouteTableAggregatePolicy `json:"Policys" name:"Policys"`
 }
 
 func (r *ReplaceCcnRouteTableAggregatePolicysRequest) ToJsonString() string {
@@ -4401,7 +4401,7 @@ type ReplaceCcnRouteTableBroadcastPolicysRequest struct {
 	RouteTableId *string `json:"RouteTableId,omitempty" name:"RouteTableId"`
 	// 新的路由传播策略
 
-	Policys []*CcnRouteTableBroadcastPolicy `json:"Policys,omitempty" name:"Policys"`
+	Policys []*CcnRouteTableBroadcastPolicy `json:"Policys" name:"Policys"`
 }
 
 func (r *ReplaceCcnRouteTableBroadcastPolicysRequest) ToJsonString() string {
@@ -5072,7 +5072,7 @@ type ReplaceCcnRouteTableInputPolicysRequest struct {
 	RouteTableId *string `json:"RouteTableId,omitempty" name:"RouteTableId"`
 	// 新的路由接收策略。
 
-	Policys []*CcnRouteTableInputPolicy `json:"Policys,omitempty" name:"Policys"`
+	Policys []*CcnRouteTableInputPolicy `json:"Policys" name:"Policys"`
 }
 
 func (r *ReplaceCcnRouteTableInputPolicysRequest) ToJsonString() string {

--- a/tencentcloud/service_tencentcloud_ccn.go
+++ b/tencentcloud/service_tencentcloud_ccn.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	ccn "terraform-provider-tencentcloudenterprise/sdk/ccn/v20170312"
+	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/ratelimit"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -818,6 +819,10 @@ func (me *VpcService) DescribeVpcReplaceCcnRouteTableInputPolicysById(ctx contex
 	ratelimit.Check(request.GetAction())
 	response, err := me.client.UseCcnClient().DescribeCcnRouteTableInputPolicys(request)
 	if err != nil {
+		// the policies are gone once the route table no longer exists
+		if sdkError, ok := err.(*sdkErrors.CloudSDKError); ok && sdkError.Code == "ResourceNotFound" {
+			return
+		}
 		errRet = err
 		return
 	}
@@ -842,6 +847,10 @@ func (me *VpcService) DescribeVpcReplaceCcnRouteTableBroadcastPolicysById(ctx co
 	ratelimit.Check(request.GetAction())
 	response, err := me.client.UseCcnClient().DescribeCcnRouteTableBroadcastPolicys(request)
 	if err != nil {
+		// the policies are gone once the route table no longer exists
+		if sdkError, ok := err.(*sdkErrors.CloudSDKError); ok && sdkError.Code == "ResourceNotFound" {
+			return
+		}
 		errRet = err
 		return
 	}


### PR DESCRIPTION
## Summary
- keep the required policy list in the CCN route table policy replace requests so an empty list is sent instead of dropped
- destroying `tencentcloudenterprise_ccn_route_table_input_policies` and `tencentcloudenterprise_ccn_route_table_broadcast_policies` now clears all policies instead of failing with a missing parameter error
- reading these resources after their route table is gone removes them from state instead of returning an error