### PR TITLE
fix(tke): sequence node pool capacity updates

### DIFF
--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
@@ -1661,31 +1661,9 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 	//
 	//}
 
-	//var capacityHasChanged = false
-	// assuming
-	// min 1 max 6 desired 2
-	// to
-	// min 3 max 6 desired 5
-	// modify min/max first will cause error, this case must upgrade desired first
-	//if d.HasChange("desired_capacity") || !desiredCapacityOutRange(d) {
-	//	desiredCapacity := int64(d.Get("desired_capacity").(int))
-	//	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-	//		errRet := service.ModifyClusterNodePoolDesiredCapacity(ctx, clusterId, nodePoolId, desiredCapacity)
-	//		if errRet != nil {
-	//			return retryError(errRet)
-	//		}
-	//		return nil
-	//	})
-	//	if err != nil {
-	//		return err
-	//	}
-	//	capacityHasChanged = true
-	//}
-
-	// ModifyClusterNodePool
-	if d.HasChanges(
-		"min_size",
-		"max_size",
+	minMaxChanged := d.HasChange("min_size") || d.HasChange("max_size")
+	desiredChanged := d.HasChange("desired_capacity")
+	nodePoolMetaChanged := d.HasChanges(
 		"name",
 		"labels",
 		"taints",
@@ -1694,48 +1672,126 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		"enable_auto_scale",
 		"node_os_type",
 		"node_os",
-	) {
-		maxSize := int64(d.Get("max_size").(int))
-		minSize := int64(d.Get("min_size").(int))
-		enableAutoScale := d.Get("enable_auto_scale").(bool)
-		name := d.Get("name").(string)
-		nodeOs := d.Get("node_os").(string)
-		nodeOsType := d.Get("node_os_type").(string)
-		labels := GetTkeLabels(d, "labels")
-		taints := GetTkeTaints(d, "taints")
-		tags := helper.GetTags(d, "tags")
+	)
 
-		// deletion protection
-		var deletionProtection *bool
-		if v, ok := d.GetOkExists("deletion_protection"); ok {
-			dp := v.(bool)
-			deletionProtection = &dp
-		}
+	enableAutoScale := d.Get("enable_auto_scale").(bool)
+	name := d.Get("name").(string)
+	nodeOs := d.Get("node_os").(string)
+	nodeOsType := d.Get("node_os_type").(string)
+	labels := GetTkeLabels(d, "labels")
+	taints := GetTkeTaints(d, "taints")
+	tags := helper.GetTags(d, "tags")
+	newMin := int64(d.Get("min_size").(int))
+	newMax := int64(d.Get("max_size").(int))
+	newDesired := int64(d.Get("desired_capacity").(int))
+	_, hasDesired := d.GetOkExists("desired_capacity")
 
-		// annotations
-		var annotations []*tke.AnnotationValue
-		if v, ok := d.GetOk("annotations"); ok {
-			for _, item := range v.(*schema.Set).List() {
-				annotationsMap := item.(map[string]interface{})
-				annotationValue := tke.AnnotationValue{}
-				if v, ok := annotationsMap["name"]; ok {
-					annotationValue.Name = helper.String(v.(string))
-				}
-				if v, ok := annotationsMap["value"]; ok {
-					annotationValue.Value = helper.String(v.(string))
-				}
-				annotations = append(annotations, &annotationValue)
+	var deletionProtection *bool
+	if v, ok := d.GetOkExists("deletion_protection"); ok {
+		dp := v.(bool)
+		deletionProtection = &dp
+	}
+
+	var annotations []*tke.AnnotationValue
+	if v, ok := d.GetOk("annotations"); ok {
+		for _, item := range v.(*schema.Set).List() {
+			annotationsMap := item.(map[string]interface{})
+			annotationValue := tke.AnnotationValue{}
+			if v, ok := annotationsMap["name"]; ok {
+				annotationValue.Name = helper.String(v.(string))
 			}
+			if v, ok := annotationsMap["value"]; ok {
+				annotationValue.Value = helper.String(v.(string))
+			}
+			annotations = append(annotations, &annotationValue)
 		}
+	}
 
-		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+	modifyNodePool := func(minSize, maxSize int64) error {
+		return resource.Retry(writeRetryTimeout, func() *resource.RetryError {
 			errRet := service.ModifyClusterNodePool(ctx, clusterId, nodePoolId, name, enableAutoScale, minSize, maxSize, nodeOs, nodeOsType, labels, taints, tags, deletionProtection, annotations)
 			if errRet != nil {
 				return retryError(errRet)
 			}
 			return nil
 		})
+	}
+
+	capacityChanged := minMaxChanged || desiredChanged
+	finalRangeApplied := false
+	if capacityChanged {
+		oldMin, _ := d.GetChange("min_size")
+		oldMax, _ := d.GetChange("max_size")
+		oldDesired, _ := d.GetChange("desired_capacity")
+		currentMin := int64(oldMin.(int))
+		currentMax := int64(oldMax.(int))
+		currentDesired := int64(oldDesired.(int))
+
+		nodePool, hasNodePool, describeErr := service.DescribeNodePool(ctx, clusterId, nodePoolId)
+		if describeErr == nil && hasNodePool && nodePool != nil {
+			if nodePool.MinNodesNum != nil {
+				currentMin = *nodePool.MinNodesNum
+			}
+			if nodePool.MaxNodesNum != nil {
+				currentMax = *nodePool.MaxNodesNum
+			}
+			if nodePool.DesiredNodesNum != nil {
+				currentDesired = *nodePool.DesiredNodesNum
+			}
+		}
+
+		updateDesired := !enableAutoScale && hasDesired && (desiredChanged || newDesired != currentDesired)
+		capacityPlan, err := planNodePoolCapacityUpdate(currentMin, currentMax, currentDesired, newMin, newMax, newDesired, updateDesired)
 		if err != nil {
+			return err
+		}
+
+		if capacityPlan.NeedTempRange {
+			if err := modifyNodePool(capacityPlan.TempMin, capacityPlan.TempMax); err != nil {
+				return err
+			}
+		}
+
+		if capacityPlan.NeedDesired {
+			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+				errRet := service.ModifyClusterNodePoolDesiredCapacity(ctx, clusterId, nodePoolId, capacityPlan.Desired)
+				if errRet != nil {
+					return retryError(errRet)
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
+				updatedPool, _, errRet := service.DescribeNodePool(ctx, clusterId, nodePoolId)
+				if errRet != nil {
+					return retryError(errRet)
+				}
+				if updatedPool == nil || updatedPool.DesiredNodesNum == nil {
+					return nil
+				}
+				if *updatedPool.DesiredNodesNum == capacityPlan.Desired {
+					return nil
+				}
+				return resource.RetryableError(fmt.Errorf("waiting for desired capacity %d, current %d", capacityPlan.Desired, *updatedPool.DesiredNodesNum))
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if capacityPlan.NeedFinalRange || nodePoolMetaChanged {
+			if err := modifyNodePool(capacityPlan.FinalMin, capacityPlan.FinalMax); err != nil {
+				return err
+			}
+			finalRangeApplied = true
+		}
+	}
+
+	if nodePoolMetaChanged && !finalRangeApplied {
+		if err := modifyNodePool(newMin, newMax); err != nil {
 			return err
 		}
 	}
@@ -1815,20 +1871,6 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 
 	}
-
-	//if d.HasChange("desired_capacity") && !capacityHasChanged {
-	//	desiredCapacity := int64(d.Get("desired_capacity").(int))
-	//	err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-	//		errRet := service.ModifyClusterNodePoolDesiredCapacity(ctx, clusterId, nodePoolId, desiredCapacity)
-	//		if errRet != nil {
-	//			return retryError(errRet)
-	//		}
-	//		return nil
-	//	})
-	//	if err != nil {
-	//		return err
-	//	}
-	//}
 
 	//if d.HasChange("auto_scaling_config.0.backup_instance_types") {
 	//	instanceTypes := getNodePoolInstanceTypes(d)

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity.go
@@ -1,0 +1,67 @@
+package tencentcloud
+
+import "fmt"
+
+type nodePoolCapacityPlan struct {
+	NeedTempRange  bool
+	TempMin        int64
+	TempMax        int64
+	NeedDesired    bool
+	Desired        int64
+	NeedFinalRange bool
+	FinalMin       int64
+	FinalMax       int64
+}
+
+func minInt64(values ...int64) int64 {
+	minValue := values[0]
+	for _, value := range values[1:] {
+		if value < minValue {
+			minValue = value
+		}
+	}
+	return minValue
+}
+
+func maxInt64(values ...int64) int64 {
+	maxValue := values[0]
+	for _, value := range values[1:] {
+		if value > maxValue {
+			maxValue = value
+		}
+	}
+	return maxValue
+}
+
+// planNodePoolCapacityUpdate keeps AS `MinSize <= DesiredCapacity <= MaxSize` while
+// min/max/desired change together. Scale-down 13/13/13 -> 3/3/3 becomes
+// [3,13] -> desired 3 -> [3,3].
+func planNodePoolCapacityUpdate(currentMin, currentMax, currentDesired, newMin, newMax, newDesired int64, updateDesired bool) (*nodePoolCapacityPlan, error) {
+	if newMin > newMax {
+		return nil, fmt.Errorf("constraints `min_size <= desired_capacity <= max_size` must be established,")
+	}
+
+	effectiveDesired := currentDesired
+	if updateDesired {
+		effectiveDesired = newDesired
+		if newDesired < newMin || newDesired > newMax {
+			return nil, fmt.Errorf("constraints `min_size <= desired_capacity <= max_size` must be established,")
+		}
+	} else if currentDesired < newMin || currentDesired > newMax {
+		return nil, fmt.Errorf("cannot set min_size=%d max_size=%d while desired_capacity is %d; keep min_size <= desired_capacity <= max_size", newMin, newMax, currentDesired)
+	}
+
+	tempMin := minInt64(currentMin, newMin, currentDesired, effectiveDesired)
+	tempMax := maxInt64(currentMax, newMax, currentDesired, effectiveDesired)
+
+	return &nodePoolCapacityPlan{
+		NeedTempRange:  tempMin != currentMin || tempMax != currentMax,
+		TempMin:        tempMin,
+		TempMax:        tempMax,
+		NeedDesired:    updateDesired && newDesired != currentDesired,
+		Desired:        newDesired,
+		NeedFinalRange: newMin != tempMin || newMax != tempMax,
+		FinalMin:       newMin,
+		FinalMax:       newMax,
+	}, nil
+}

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity_test.go
@@ -1,0 +1,143 @@
+package tencentcloud
+
+import "testing"
+
+func TestPlanNodePoolCapacityUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		currentMin     int64
+		currentMax     int64
+		currentDesired int64
+		newMin         int64
+		newMax         int64
+		newDesired     int64
+		updateDesired  bool
+		wantErr        bool
+		wantTemp       bool
+		tempMin        int64
+		tempMax        int64
+		wantDesired    bool
+		wantFinal      bool
+		finalMin       int64
+		finalMax       int64
+	}{
+		{
+			name:           "scale down min/max/desired together",
+			currentMin:     13,
+			currentMax:     13,
+			currentDesired: 13,
+			newMin:         3,
+			newMax:         3,
+			newDesired:     3,
+			updateDesired:  true,
+			wantTemp:       true,
+			tempMin:        3,
+			tempMax:        13,
+			wantDesired:    true,
+			wantFinal:      true,
+			finalMin:       3,
+			finalMax:       3,
+		},
+		{
+			name:           "scale up min and desired",
+			currentMin:     1,
+			currentMax:     6,
+			currentDesired: 2,
+			newMin:         3,
+			newMax:         6,
+			newDesired:     5,
+			updateDesired:  true,
+			wantTemp:       false,
+			tempMin:        1,
+			tempMax:        6,
+			wantDesired:    true,
+			wantFinal:      true,
+			finalMin:       3,
+			finalMax:       6,
+		},
+		{
+			name:           "desired only",
+			currentMin:     1,
+			currentMax:     6,
+			currentDesired: 2,
+			newMin:         1,
+			newMax:         6,
+			newDesired:     5,
+			updateDesired:  true,
+			wantTemp:       false,
+			tempMin:        1,
+			tempMax:        6,
+			wantDesired:    true,
+			wantFinal:      false,
+			finalMin:       1,
+			finalMax:       6,
+		},
+		{
+			name:           "expand max only",
+			currentMin:     1,
+			currentMax:     6,
+			currentDesired: 2,
+			newMin:         1,
+			newMax:         10,
+			newDesired:     2,
+			updateDesired:  false,
+			wantTemp:       true,
+			tempMin:        1,
+			tempMax:        10,
+			wantDesired:    false,
+			wantFinal:      false,
+			finalMin:       1,
+			finalMax:       10,
+		},
+		{
+			name:           "min above current desired without desired change",
+			currentMin:     1,
+			currentMax:     10,
+			currentDesired: 2,
+			newMin:         5,
+			newMax:         10,
+			newDesired:     2,
+			updateDesired:  false,
+			wantErr:        true,
+		},
+		{
+			name:           "desired outside new range",
+			currentMin:     1,
+			currentMax:     6,
+			currentDesired: 2,
+			newMin:         1,
+			newMax:         6,
+			newDesired:     10,
+			updateDesired:  true,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			plan, err := planNodePoolCapacityUpdate(tt.currentMin, tt.currentMax, tt.currentDesired, tt.newMin, tt.newMax, tt.newDesired, tt.updateDesired)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if plan.NeedTempRange != tt.wantTemp || plan.TempMin != tt.tempMin || plan.TempMax != tt.tempMax {
+				t.Fatalf("temp range = (%v,%d,%d), want (%v,%d,%d)", plan.NeedTempRange, plan.TempMin, plan.TempMax, tt.wantTemp, tt.tempMin, tt.tempMax)
+			}
+			if plan.NeedDesired != tt.wantDesired || (tt.wantDesired && plan.Desired != tt.newDesired) {
+				t.Fatalf("desired = (%v,%d), want (%v,%d)", plan.NeedDesired, plan.Desired, tt.wantDesired, tt.newDesired)
+			}
+			if plan.NeedFinalRange != tt.wantFinal || plan.FinalMin != tt.finalMin || plan.FinalMax != tt.finalMax {
+				t.Fatalf("final range = (%v,%d,%d), want (%v,%d,%d)", plan.NeedFinalRange, plan.FinalMin, plan.FinalMax, tt.wantFinal, tt.finalMin, tt.finalMax)
+			}
+		})
+	}
+}

--- a/tencentcloud/service_tencentcloud_tke.go
+++ b/tencentcloud/service_tencentcloud_tke.go
@@ -1582,27 +1582,27 @@ func (me *TkeService) ModifyClusterNodePoolPreStartUserScript(ctx context.Contex
 	return
 }
 
-//func (me *TkeService) ModifyClusterNodePoolDesiredCapacity(ctx context.Context, clusterId, nodePoolId string, desiredCapacity int64) (errRet error) {
-//	logId := getLogId(ctx)
-//	request := tke.NewModifyNodePoolDesiredCapacityAboutAsgRequest()
-//
-//	defer func() {
-//		if errRet != nil {
-//			log.Printf("[CRITAL]%s api[%s] fail, reason[%s]\n", logId, request.GetAction(), errRet.Error())
-//		}
-//	}()
-//	request.ClusterId = &clusterId
-//	request.NodePoolId = &nodePoolId
-//	request.DesiredCapacity = &desiredCapacity
-//
-//	ratelimit.Check(request.GetAction())
-//	_, err := me.client.UseTkeClient().ModifyNodePoolDesiredCapacityAboutAsg(request)
-//	if err != nil {
-//		errRet = err
-//		return
-//	}
-//	return
-//}
+func (me *TkeService) ModifyClusterNodePoolDesiredCapacity(ctx context.Context, clusterId, nodePoolId string, desiredCapacity int64) (errRet error) {
+	logId := getLogId(ctx)
+	request := tke.NewModifyNodePoolDesiredCapacityAboutAsgRequest()
+
+	defer func() {
+		if errRet != nil {
+			log.Printf("[CRITAL]%s api[%s] fail, reason[%s]\n", logId, request.GetAction(), errRet.Error())
+		}
+	}()
+	request.ClusterId = &clusterId
+	request.NodePoolId = &nodePoolId
+	request.DesiredCapacity = &desiredCapacity
+
+	ratelimit.Check(request.GetAction())
+	_, err := me.client.UseTkeClient().ModifyNodePoolDesiredCapacityAboutAsg(request)
+	if err != nil {
+		errRet = err
+		return
+	}
+	return
+}
 
 //func (me *TkeService) ModifyClusterNodePoolInstanceTypes(ctx context.Context, clusterId, nodePoolId string, instanceTypes []*string) (errRet error) {
 //	logId := getLogId(ctx)


### PR DESCRIPTION
## Summary
- keep Auto Scaling `MinSize <= DesiredCapacity <= MaxSize` when min, max, and desired change together
- scale a node pool down in one apply by widening the range, updating desired capacity, then applying the final min/max
- restore desired-capacity updates through the dedicated node pool ASG API