### PR TITLE
fix(tke): wait for node pool ready before updates

### DIFF
--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
@@ -1709,13 +1709,17 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
 			return err
 		}
-		return resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
 			errRet := service.ModifyClusterNodePool(ctx, clusterId, nodePoolId, name, enableAutoScale, minSize, maxSize, nodeOs, nodeOsType, labels, taints, tags, deletionProtection, annotations)
 			if errRet != nil {
 				return retryNodePoolWriteError(errRet)
 			}
 			return nil
 		})
+		if err != nil {
+			return err
+		}
+		return waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout)
 	}
 	modifyDesired := func(desired int64) error {
 		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
@@ -1731,7 +1735,10 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		if err != nil {
 			return err
 		}
-		return waitNodePoolDesiredCapacity(ctx, service, clusterId, nodePoolId, desired, nodePoolReadyTimeout)
+		if err := waitNodePoolDesiredCapacity(ctx, service, clusterId, nodePoolId, desired, nodePoolReadyTimeout); err != nil {
+			return err
+		}
+		return waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout)
 	}
 
 	needCapacityWrite := minMaxChanged || (!enableAutoScale && hasDesired && desiredChanged)
@@ -1793,17 +1800,23 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if d.HasChange("node_config.0.pre_start_user_script") {
+	if d.HasChange("node_config.0.user_data") || d.HasChange("node_config.0.pre_start_user_script") {
+		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
+			return err
+		}
 		userData, _ := d.Get("node_config.0.user_data").(string)
 		preStartUserScript, _ := d.Get("node_config.0.pre_start_user_script").(string)
 		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
 			errRet := service.ModifyClusterNodePoolPreStartUserScript(ctx, clusterId, nodePoolId, userData, preStartUserScript)
 			if errRet != nil {
-				return retryError(errRet)
+				return retryNodePoolWriteError(errRet)
 			}
 			return nil
 		})
 		if err != nil {
+			return err
+		}
+		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
 			return err
 		}
 	}
@@ -1815,6 +1828,10 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		d.HasChange("multi_zone_subnet_policy") ||
 		d.HasChange("default_cooldown") ||
 		d.HasChange("termination_policies") {
+
+		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
+			return err
+		}
 
 		nodePool, _, err := service.DescribeNodePool(ctx, clusterId, nodePoolId)
 		if err != nil {

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool.go
@@ -153,14 +153,16 @@ package tencentcloud
 import (
 	"context"
 	"fmt"
-	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
 	"strings"
+	"time"
 
+	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	as "terraform-provider-tencentcloudenterprise/sdk/as/v20180419"
 	tke "terraform-provider-tencentcloudenterprise/sdk/tke/v20180525"
 	"terraform-provider-tencentcloudenterprise/tencentcloud/internal/helper"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func init() {
@@ -285,30 +287,30 @@ func composedKubernetesAsScalingConfigPara() map[string]*schema.Schema {
 						Default:     0,
 						Description: "Volume of disk in GB. Default is `0`.",
 					},
-				"snapshot_id": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Computed:    true,
-					ForceNew:    true,
-					Description: "Data disk snapshot ID.",
-				},
-				"delete_with_instance": {
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Computed:    true,
-					Description: "Indicates whether the disk remove after instance terminated. Default is `false`.",
-				},
-				"encrypt": {
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Description: "Specify whether to encrypt data disk, default: false. NOTE: Make sure the instance type is offering and the cam role `QcloudKMSAccessForCVMRole` was provided.",
-				},
-				"throughput_performance": {
-					Type:        schema.TypeInt,
-					Optional:    true,
-					Computed:    true,
-					Description: "Add extra performance to the data disk. Only works when disk type is `CLOUD_TSSD` or `CLOUD_HSSD` and `data_size` > 460GB.",
-				},
+					"snapshot_id": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Computed:    true,
+						ForceNew:    true,
+						Description: "Data disk snapshot ID.",
+					},
+					"delete_with_instance": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Computed:    true,
+						Description: "Indicates whether the disk remove after instance terminated. Default is `false`.",
+					},
+					"encrypt": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Specify whether to encrypt data disk, default: false. NOTE: Make sure the instance type is offering and the cam role `QcloudKMSAccessForCVMRole` was provided.",
+					},
+					"throughput_performance": {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Computed:    true,
+						Description: "Add extra performance to the data disk. Only works when disk type is `CLOUD_TSSD` or `CLOUD_HSSD` and `data_size` > 460GB.",
+					},
 				},
 			},
 		},
@@ -1122,11 +1124,11 @@ func resourceKubernetesNodePoolRead(d *schema.ResourceData, meta interface{}) er
 	defer logElapsed("resource.tencentcloudenterprise_tke_kubernetes_node_pool.read")()
 
 	var (
-		logId   = getLogId(contextNil)
-		ctx     = context.WithValue(context.TODO(), logIdKey, logId)
-		service = TkeService{client: meta.(*TencentCloudClient).apiV3Conn}
+		logId     = getLogId(contextNil)
+		ctx       = context.WithValue(context.TODO(), logIdKey, logId)
+		service   = TkeService{client: meta.(*TencentCloudClient).apiV3Conn}
 		asService = AsService{client: meta.(*TencentCloudClient).apiV3Conn}
-		items = strings.Split(d.Id(), FILED_SP)
+		items     = strings.Split(d.Id(), FILED_SP)
 	)
 	if len(items) != 2 {
 		return fmt.Errorf("resource_tc_kubernetes_node_pool id  is broken")
@@ -1600,18 +1602,7 @@ func resourceKubernetesNodePoolCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	// wait for status ok
-	err = resource.Retry(5*readRetryTimeout, func() *resource.RetryError {
-		nodePool, _, errRet := service.DescribeNodePool(ctx, clusterId, nodePoolId)
-		if errRet != nil {
-			return retryError(errRet, InternalError)
-		}
-		if nodePool != nil && *nodePool.LifeState == "normal" {
-			return nil
-		}
-		return resource.RetryableError(fmt.Errorf("node pool status is %s, retry...", *nodePool.LifeState))
-	})
-	if err != nil {
+	if err = waitNodePoolNormal(ctx, service, clusterId, nodePoolId, 5*readRetryTimeout); err != nil {
 		return err
 	}
 
@@ -1707,19 +1698,49 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
+	nodePoolReadyTimeout := 5 * readRetryTimeout
+	retryNodePoolWriteError := func(err error) *resource.RetryError {
+		if isBareOperationDenied(err) {
+			return resource.RetryableError(err)
+		}
+		return retryError(err)
+	}
 	modifyNodePool := func(minSize, maxSize int64) error {
+		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
+			return err
+		}
 		return resource.Retry(writeRetryTimeout, func() *resource.RetryError {
 			errRet := service.ModifyClusterNodePool(ctx, clusterId, nodePoolId, name, enableAutoScale, minSize, maxSize, nodeOs, nodeOsType, labels, taints, tags, deletionProtection, annotations)
 			if errRet != nil {
-				return retryError(errRet)
+				return retryNodePoolWriteError(errRet)
 			}
 			return nil
 		})
 	}
+	modifyDesired := func(desired int64) error {
+		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
+			return err
+		}
+		err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
+			errRet := service.ModifyClusterNodePoolDesiredCapacity(ctx, clusterId, nodePoolId, desired)
+			if errRet != nil {
+				return retryNodePoolWriteError(errRet)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		return waitNodePoolDesiredCapacity(ctx, service, clusterId, nodePoolId, desired, nodePoolReadyTimeout)
+	}
 
-	capacityChanged := minMaxChanged || desiredChanged
+	needCapacityWrite := minMaxChanged || (!enableAutoScale && hasDesired && desiredChanged)
 	finalRangeApplied := false
-	if capacityChanged {
+	if needCapacityWrite {
+		if err := waitNodePoolNormal(ctx, service, clusterId, nodePoolId, nodePoolReadyTimeout); err != nil {
+			return err
+		}
+
 		oldMin, _ := d.GetChange("min_size")
 		oldMax, _ := d.GetChange("max_size")
 		oldDesired, _ := d.GetChange("desired_capacity")
@@ -1753,31 +1774,7 @@ func resourceKubernetesNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if capacityPlan.NeedDesired {
-			err := resource.Retry(writeRetryTimeout, func() *resource.RetryError {
-				errRet := service.ModifyClusterNodePoolDesiredCapacity(ctx, clusterId, nodePoolId, capacityPlan.Desired)
-				if errRet != nil {
-					return retryError(errRet)
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-
-			err = resource.Retry(readRetryTimeout, func() *resource.RetryError {
-				updatedPool, _, errRet := service.DescribeNodePool(ctx, clusterId, nodePoolId)
-				if errRet != nil {
-					return retryError(errRet)
-				}
-				if updatedPool == nil || updatedPool.DesiredNodesNum == nil {
-					return nil
-				}
-				if *updatedPool.DesiredNodesNum == capacityPlan.Desired {
-					return nil
-				}
-				return resource.RetryableError(fmt.Errorf("waiting for desired capacity %d, current %d", capacityPlan.Desired, *updatedPool.DesiredNodesNum))
-			})
-			if err != nil {
+			if err := modifyDesired(capacityPlan.Desired); err != nil {
 				return err
 			}
 		}
@@ -1960,4 +1957,49 @@ func resourceKubernetesNodePoolDelete(d *schema.ResourceData, meta interface{}) 
 	})
 
 	return err
+}
+
+func waitNodePoolNormal(ctx context.Context, service TkeService, clusterId, nodePoolId string, timeout time.Duration) error {
+	return resource.Retry(timeout, func() *resource.RetryError {
+		pool, has, errRet := service.DescribeNodePool(ctx, clusterId, nodePoolId)
+		if errRet != nil {
+			return retryError(errRet, InternalError)
+		}
+		var lifeState *string
+		if pool != nil {
+			lifeState = pool.LifeState
+		}
+		action, state := nodePoolWaitDecision(has && pool != nil, lifeState)
+		switch action {
+		case nodePoolWaitReady:
+			return nil
+		case nodePoolWaitFail:
+			if state == "not found" {
+				return resource.NonRetryableError(fmt.Errorf("node pool %s not found", nodePoolId))
+			}
+			return resource.NonRetryableError(fmt.Errorf("node pool %s is %s", nodePoolId, state))
+		default:
+			return resource.RetryableError(fmt.Errorf("node pool %s is %s, retry...", nodePoolId, state))
+		}
+	})
+}
+
+func waitNodePoolDesiredCapacity(ctx context.Context, service TkeService, clusterId, nodePoolId string, desired int64, timeout time.Duration) error {
+	return resource.Retry(timeout, func() *resource.RetryError {
+		pool, has, errRet := service.DescribeNodePool(ctx, clusterId, nodePoolId)
+		if errRet != nil {
+			return retryError(errRet, InternalError)
+		}
+		if !has || pool == nil {
+			return resource.NonRetryableError(fmt.Errorf("node pool %s not found", nodePoolId))
+		}
+		if pool.DesiredNodesNum == nil || *pool.DesiredNodesNum != desired {
+			current := int64(-1)
+			if pool.DesiredNodesNum != nil {
+				current = *pool.DesiredNodesNum
+			}
+			return resource.RetryableError(fmt.Errorf("waiting for desired capacity %d, current %d", desired, current))
+		}
+		return nil
+	})
 }

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity.go
@@ -1,6 +1,12 @@
 package tencentcloud
 
-import "fmt"
+import (
+	"fmt"
+
+	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
+
+	"github.com/pkg/errors"
+)
 
 type nodePoolCapacityPlan struct {
 	NeedTempRange  bool
@@ -12,6 +18,14 @@ type nodePoolCapacityPlan struct {
 	FinalMin       int64
 	FinalMax       int64
 }
+
+type nodePoolWaitAction int
+
+const (
+	nodePoolWaitReady nodePoolWaitAction = iota
+	nodePoolWaitRetry
+	nodePoolWaitFail
+)
 
 func minInt64(values ...int64) int64 {
 	minValue := values[0]
@@ -64,4 +78,33 @@ func planNodePoolCapacityUpdate(currentMin, currentMax, currentDesired, newMin, 
 		FinalMin:       newMin,
 		FinalMax:       newMax,
 	}, nil
+}
+
+func nodePoolWaitDecision(has bool, lifeState *string) (nodePoolWaitAction, string) {
+	if !has {
+		return nodePoolWaitFail, "not found"
+	}
+	state := "unknown"
+	if lifeState != nil {
+		state = *lifeState
+	}
+	switch state {
+	case "normal":
+		return nodePoolWaitReady, state
+	case "abnormal":
+		return nodePoolWaitFail, state
+	default:
+		return nodePoolWaitRetry, state
+	}
+}
+
+func isBareOperationDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	sdkErr, ok := err.(*sdkErrors.CloudSDKError)
+	if !ok {
+		sdkErr, ok = errors.Cause(err).(*sdkErrors.CloudSDKError)
+	}
+	return ok && sdkErr.Code == "OperationDenied"
 }

--- a/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity_test.go
+++ b/tencentcloud/resource_tc_tke_kubernetes_node_pool_capacity_test.go
@@ -1,6 +1,10 @@
 package tencentcloud
 
-import "testing"
+import (
+	"testing"
+
+	sdkErrors "terraform-provider-tencentcloudenterprise/sdk/common/errors"
+)
 
 func TestPlanNodePoolCapacityUpdate(t *testing.T) {
 	t.Parallel()
@@ -139,5 +143,55 @@ func TestPlanNodePoolCapacityUpdate(t *testing.T) {
 				t.Fatalf("final range = (%v,%d,%d), want (%v,%d,%d)", plan.NeedFinalRange, plan.FinalMin, plan.FinalMax, tt.wantFinal, tt.finalMin, tt.finalMax)
 			}
 		})
+	}
+}
+
+func TestNodePoolWaitDecision(t *testing.T) {
+	t.Parallel()
+
+	updating := "updating"
+	normal := "normal"
+	abnormal := "abnormal"
+
+	tests := []struct {
+		name      string
+		has       bool
+		lifeState *string
+		want      nodePoolWaitAction
+		wantState string
+	}{
+		{name: "missing pool", has: false, want: nodePoolWaitFail, wantState: "not found"},
+		{name: "nil life state", has: true, want: nodePoolWaitRetry, wantState: "unknown"},
+		{name: "updating", has: true, lifeState: &updating, want: nodePoolWaitRetry, wantState: "updating"},
+		{name: "normal", has: true, lifeState: &normal, want: nodePoolWaitReady, wantState: "normal"},
+		{name: "abnormal", has: true, lifeState: &abnormal, want: nodePoolWaitFail, wantState: "abnormal"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, state := nodePoolWaitDecision(tt.has, tt.lifeState)
+			if got != tt.want || state != tt.wantState {
+				t.Fatalf("nodePoolWaitDecision() = (%v,%q), want (%v,%q)", got, state, tt.want, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestIsBareOperationDenied(t *testing.T) {
+	t.Parallel()
+
+	if isBareOperationDenied(nil) {
+		t.Fatal("nil should not match")
+	}
+	if !isBareOperationDenied(sdkErrors.NewCloudSDKError("OperationDenied", "denied", "req-1")) {
+		t.Fatal("bare OperationDenied should match")
+	}
+	if isBareOperationDenied(sdkErrors.NewCloudSDKError("OperationDenied.ClusterInDeletionProtection", "protected", "req-2")) {
+		t.Fatal("OperationDenied subcode should not match")
+	}
+	if isBareOperationDenied(sdkErrors.NewCloudSDKError("InvalidParameterValue.Size", "size", "req-3")) {
+		t.Fatal("unrelated code should not match")
 	}
 }


### PR DESCRIPTION
## Summary
- wait until a node pool returns to normal before the next capacity, label, or startup-script change
- retry only a bare OperationDenied while the pool is still updating
- keep combined node pool updates valid in a single apply