### PR TITLE
fix(csp): avoid provider crash when creating a bucket

### DIFF
--- a/tencentcloud/data_source_tc_cos_bucket_object.go
+++ b/tencentcloud/data_source_tc_cos_bucket_object.go
@@ -281,8 +281,11 @@ func dataSourceTencentCloudCosBucketObjectsRead(ctx context.Context, d *schema.R
 		content["last_modified"] = v.LastModified
 		content["etag"] = v.ETag
 		content["size"] = v.Size
-		content["owner_id"] = v.Owner.ID
-		content["display_name"] = v.Owner.DisplayName
+		// 列举对象时服务端仅在请求带 fetch-owner 时才返回 Owner，该选项当前不可设置
+		if v.Owner != nil {
+			content["owner_id"] = v.Owner.ID
+			content["display_name"] = v.Owner.DisplayName
+		}
 		content["storage_class"] = v.StorageClass
 		contents = append(contents, content)
 	}

--- a/tencentcloud/data_source_tc_cos_buckets.go
+++ b/tencentcloud/data_source_tc_cos_buckets.go
@@ -468,14 +468,19 @@ func dataSourceTencentCloudCosBucketsRead(d *schema.ResourceData, meta interface
 
 	ids := make([]string, 2)
 	ids[0] = "bucket_list"
-	ids[1] = bucketResult.Owner.ID
+	// 桶在服务端没有归属记录时 Owner 为空，此时仍返回桶列表而不是崩溃
+	if bucketResult.Owner != nil {
+		ids[1] = bucketResult.Owner.ID
+	}
 	d.SetId(helper.DataResourceIdsHash(ids))
 	if err := d.Set("bucket_list", bucketList); err != nil {
 		return fmt.Errorf("setting bucket list error: %s", err.Error())
 	}
 	owner := make(map[string]interface{})
-	owner["id"] = bucketResult.Owner.ID
-	owner["display_name"] = bucketResult.Owner.DisplayName
+	if bucketResult.Owner != nil {
+		owner["id"] = bucketResult.Owner.ID
+		owner["display_name"] = bucketResult.Owner.DisplayName
+	}
 	if err := d.Set("owner", owner); err != nil {
 		return fmt.Errorf("setting owner error: %s", err.Error())
 	}

--- a/tencentcloud/data_source_tc_csp_bucket_object.go
+++ b/tencentcloud/data_source_tc_csp_bucket_object.go
@@ -289,8 +289,11 @@ func dataSourceTencentCloudCspBucketObjectsRead(ctx context.Context, d *schema.R
 		content["last_modified"] = v.LastModified
 		content["etag"] = v.ETag
 		content["size"] = v.Size
-		content["owner_id"] = v.Owner.ID
-		content["display_name"] = v.Owner.DisplayName
+		// 列举对象时服务端仅在请求带 fetch-owner 时才返回 Owner，该选项当前不可设置
+		if v.Owner != nil {
+			content["owner_id"] = v.Owner.ID
+			content["display_name"] = v.Owner.DisplayName
+		}
 		content["storage_class"] = v.StorageClass
 		contents = append(contents, content)
 	}

--- a/tencentcloud/data_source_tc_csp_buckets.go
+++ b/tencentcloud/data_source_tc_csp_buckets.go
@@ -471,14 +471,19 @@ func dataSourceTencentCloudCspBucketsRead(d *schema.ResourceData, meta interface
 
 	ids := make([]string, 2)
 	ids[0] = "bucket_list"
-	ids[1] = bucketResult.Owner.ID
+	// 桶在服务端没有归属记录时 Owner 为空，此时仍返回桶列表而不是崩溃
+	if bucketResult.Owner != nil {
+		ids[1] = bucketResult.Owner.ID
+	}
 	d.SetId(helper.DataResourceIdsHash(ids))
 	if err := d.Set("bucket_list", bucketList); err != nil {
 		return fmt.Errorf("setting bucket list error: %s", err.Error())
 	}
 	owner := make(map[string]interface{})
-	owner["id"] = bucketResult.Owner.ID
-	owner["display_name"] = bucketResult.Owner.DisplayName
+	if bucketResult.Owner != nil {
+		owner["id"] = bucketResult.Owner.ID
+		owner["display_name"] = bucketResult.Owner.DisplayName
+	}
 	if err := d.Set("owner", owner); err != nil {
 		return fmt.Errorf("setting owner error: %s", err.Error())
 	}

--- a/tencentcloud/resource_tc_csp_bucket.go
+++ b/tencentcloud/resource_tc_csp_bucket.go
@@ -356,9 +356,8 @@ func resourceTencentCloudCspBucket() *schema.Resource {
 		Update:      resourceTencentCloudCspBucketUpdate,
 		Delete:      resourceTencentCloudCspBucketDelete,
 		Importer: &schema.ResourceImporter{
-			State: helper.ImportWithDefaultValue(map[string]interface{}{
-				"force_clean": false,
-			}),
+			// csp 桶未开放 force_clean 参数，导入时不能回填该字段
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tencentcloud/service_tencentcloud_cos.go
+++ b/tencentcloud/service_tencentcloud_cos.go
@@ -1154,7 +1154,7 @@ func (c *CosService) GetBucketACL(ctx context.Context, bucket string) (result *c
 	}
 
 	// 转换 S3 ACL 响应为 cos.BucketGetACLResult 格式
-	// Owner 与 Grantee 均为可选字段，部分端点不返回，缺失时跳过而不是中断读取
+	// Owner 与 Grantee 均为可选字段，缺失时跳过而不是中断读取
 	result = &cos.BucketGetACLResult{
 		AccessControlList: make([]cos.ACLGrant, 0, len(response.Grants)),
 	}
@@ -1164,6 +1164,11 @@ func (c *CosService) GetBucketACL(ctx context.Context, bucket string) (result *c
 			ID:          aws.StringValue(response.Owner.ID),
 			DisplayName: aws.StringValue(response.Owner.DisplayName),
 		}
+	} else {
+		// 归属正常的桶一定会返回 Owner；为空说明服务端没有该桶的归属记录，
+		// 这类桶通常也不会出现在按账号过滤的桶列表和控制台里
+		log.Printf("[WARN]%s api[%s] bucket (%s) returned no owner, "+
+			"it may not be registered to any account\n", logId, "GetBucketACL", bucket)
 	}
 
 	for _, grant := range response.Grants {

--- a/tencentcloud/service_tencentcloud_cos.go
+++ b/tencentcloud/service_tencentcloud_cos.go
@@ -1154,29 +1154,30 @@ func (c *CosService) GetBucketACL(ctx context.Context, bucket string) (result *c
 	}
 
 	// 转换 S3 ACL 响应为 cos.BucketGetACLResult 格式
-	if response.Owner == nil {
-		errRet = fmt.Errorf("cos [GetBucketACL] error: owner is nil, bucket: %s", bucket)
-	}
+	// Owner 与 Grantee 均为可选字段，部分端点不返回，缺失时跳过而不是中断读取
 	result = &cos.BucketGetACLResult{
-		Owner: &cos.Owner{
-			ID:          *response.Owner.ID,
-			DisplayName: *response.Owner.DisplayName,
-		},
-		AccessControlList: make([]cos.ACLGrant, len(response.Grants)),
+		AccessControlList: make([]cos.ACLGrant, 0, len(response.Grants)),
 	}
 
-	for i, grant := range response.Grants {
+	if response.Owner != nil {
+		result.Owner = &cos.Owner{
+			ID:          aws.StringValue(response.Owner.ID),
+			DisplayName: aws.StringValue(response.Owner.DisplayName),
+		}
+	}
+
+	for _, grant := range response.Grants {
 		if grant.Grantee == nil {
 			continue
 		}
-		result.AccessControlList[i] = cos.ACLGrant{
+		result.AccessControlList = append(result.AccessControlList, cos.ACLGrant{
 			Grantee: &cos.ACLGrantee{
-				Type: *grant.Grantee.Type,
+				Type: aws.StringValue(grant.Grantee.Type),
 				URI:  aws.StringValue(grant.Grantee.URI),
 				ID:   aws.StringValue(grant.Grantee.ID),
 			},
-			Permission: *grant.Permission,
-		}
+			Permission: aws.StringValue(grant.Permission),
+		})
 	}
 
 	log.Printf("[DEBUG]%s api[%s] success\n", logId, "GetBucketACL")


### PR DESCRIPTION
## Summary
- creating `tencentcloudenterprise_csp_bucket` no longer crashes the provider when the bucket ACL response omits the owner
- bucket ACL grants without a grantee are skipped instead of producing empty entries
- importing `tencentcloudenterprise_csp_bucket` now succeeds instead of failing on the unsupported `force_clean` argument