### PR TITLE
fix(cvm): correct Image.Flags type to string array

### DIFF
--- a/sdk/cvm/v20170312/models.go
+++ b/sdk/cvm/v20170312/models.go
@@ -5393,7 +5393,7 @@ type Image struct {
 	OperationMask *int64 `json:"OperationMask,omitempty" name:"OperationMask"`
 	// 镜像标记
 
-	Flags *string `json:"Flags,omitempty" name:"Flags"`
+	Flags []*string `json:"Flags,omitempty" name:"Flags"`
 	// 自定义镜像id
 
 	DeviceImageId *int64 `json:"DeviceImageId,omitempty" name:"DeviceImageId"`


### PR DESCRIPTION
## Summary
- decode `DescribeImages` image flags as a list of strings to match the API contract
- reading or importing `tencentcloudenterprise_cvm_instance` no longer fails with a JSON parse error
- the `tencentcloudenterprise_cvm_image` and `tencentcloudenterprise_cvm_images` data sources work again on clusters that return image flags